### PR TITLE
Add resource limits to the TAS deployment file

### DIFF
--- a/telemetry-aware-scheduling/deploy/tas-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-deployment.yaml
@@ -31,6 +31,13 @@ spec:
         volumeMounts:
         - name: certs
           mountPath: /tas/cert
+        resources:
+          limits:
+            memory: "500Mi"
+            cpu: "500m"
+          requests:
+            memory: "100Mi"
+            cpu: "100m"
       volumes:
       - name: certs
         secret:
@@ -45,3 +52,4 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
+


### PR DESCRIPTION
This change adds resource limits and requests to the TAS yaml.
The requests are set high and leave TAS as a burstable pod. These
changes should protect from potential overuse of resources by TAS