### PR TITLE
End to end tests with KIND

### DIFF
--- a/.github/e2e/e2e_test.go
+++ b/.github/e2e/e2e_test.go
@@ -1,0 +1,308 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/metrics"
+	"github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/deschedule"
+	"github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/dontschedule"
+	"github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/scheduleonmetric"
+	api "github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1"
+	tasclient "github.com/intel/telemetry-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/client/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	"path/filepath"
+)
+
+/*
+Metrics values are currently set with a mount file which is then read by the node exporter. This behaviour could be
+changed in future to allow the setting of metrics natively inside the e2e testing code. For this first iteration a new
+metric and policy will be used for each of the three e2e smoke tests being reviewed.
+
+*/
+
+var (
+	kubeConfigPath *string
+	cl             *kubernetes.Clientset
+	tascl          *tasclient.Client
+	cm             metrics.CustomMetricsClient
+)
+
+//init sets up the clients used for the end to end tests
+func init() {
+	if home := homedir.HomeDir(); home != "" {
+		kubeConfigPath = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "path to your kubeconfig file")
+	} else {
+		kubeConfigPath = flag.String("kubeconfig", "", "require absolute path to your kubeconfig file")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigPath)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// create the clientset
+	cl, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+	cm = metrics.NewClient(config)
+
+	tascl, err = tasclient.New(*config, "default")
+	if err != nil {
+		panic(err.Error())
+	}
+	//TODO: Replace the generic timeout with an explicit check for the custom metrics from the API Server which times out after some period
+	err = waitForMetrics(120 * time.Second)
+
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+var (
+	prioritize1Policy = getTASPolicy("prioritize1", scheduleonmetric.StrategyType, "prioritize1_metric", "GreaterThan", 0)
+	filter1Policy     = getTASPolicy("filter1", dontschedule.StrategyType, "filter1_metric", "LessThan", 20)
+	filter2Policy     = getTASPolicy("filter2", dontschedule.StrategyType, "filter2_metric", "Equals", 0)
+	deschedule1Policy = getTASPolicy("deschedule1", deschedule.StrategyType, "deschedule1_metric", "GreaterThan", 8)
+)
+
+// TestTASPrioritize will test the behaviour of a pod with a listed deschedule policy in TAS
+func TestTASDeschedule(t *testing.T) {
+	tests := map[string]struct {
+		policy *api.TASPolicy
+		want   map[string]bool
+	}{
+		"Label node for deschedule": {policy: deschedule1Policy, want: map[string]bool{"kind-worker2": true}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := map[string]bool{}
+			log.Printf("Running: %v\n", name)
+			//defer the running of a cleanup function to remove the policy and pod after the test case
+			defer cleanup("", tc.policy.Name)
+			_, err := tascl.Create(tc.policy)
+			if err != nil {
+				log.Print(err)
+			}
+			time.Sleep(time.Second * 5)
+			lbls := metav1.LabelSelector{MatchLabels: map[string]string{deschedule1Policy.Name: "violating"}}
+
+			nodes, err := cl.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(lbls.MatchLabels).String()})
+			if err != nil {
+				log.Print(err)
+			}
+			for _, n := range nodes.Items {
+				res[n.Name] = true
+			}
+			if !reflect.DeepEqual(tc.want, res) {
+				//Log full node specs and TAS Pod log if the test fails
+				nodes, _ = cl.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+				log.Print(tasLog())
+				for _, n := range nodes.Items {
+					log.Printf("%v labels: %v", n.Name, n.ObjectMeta.Labels)
+				}
+				t.Errorf("expected: %v, got: %v", tc.want, res)
+			}
+		})
+	}
+}
+
+// TestTASFilter will test the behaviour of a pod with a listed filter/dontschedule policy in TAS
+func TestTASFilter(t *testing.T) {
+	tests := map[string]struct {
+		policy *api.TASPolicy
+		pod    *v1.Pod
+		want   string
+	}{
+		"Filter all but one node": {policy: filter1Policy, pod: podForPolicy(fmt.Sprintf("pod-%v", time.Now().Unix()), filter1Policy.Name), want: "kind-worker2"},
+		"Filter all nodes":        {policy: filter2Policy, pod: podForPolicy(fmt.Sprintf("pod-%v", rand.String(8)), filter2Policy.Name), want: ""},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			log.Printf("Running: %v\n", name)
+			//defer the running of a cleanup function to remove the policy and pod after the test case
+			defer cleanup(tc.pod.Name, tc.policy.Name)
+
+			_, err := tascl.Create(tc.policy)
+			if err != nil {
+				log.Print(err)
+			}
+			time.Sleep(time.Second * 5)
+			_, err = cl.CoreV1().Pods("default").Create(context.TODO(), tc.pod, metav1.CreateOptions{})
+			if err != nil {
+				log.Print(err)
+			}
+
+			time.Sleep(time.Second * 5)
+			p, _ := cl.CoreV1().Pods("default").Get(context.TODO(), tc.pod.Name, metav1.GetOptions{})
+			log.Print(p.Name)
+			if !reflect.DeepEqual(tc.want, p.Spec.NodeName) {
+				t.Errorf("expected: %v, got: %v", tc.want, p.Spec.NodeName)
+			}
+		})
+	}
+
+}
+
+// TestTASPrioritize will test the behaviour of a pod with a listed prioritize/scheduleonmetric policy in TAS
+func TestTASPrioritize(t *testing.T) {
+	tests := map[string]struct {
+		policy *api.TASPolicy
+		pod    *v1.Pod
+		want   string
+	}{
+		"Prioritize to highest score node": {policy: prioritize1Policy, pod: podForPolicy(fmt.Sprintf("pod-%v", time.Now().Unix()), prioritize1Policy.Name), want: "kind-worker2"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			log.Printf("Running: %v\n", name)
+			//defer the running of a cleanup function to remove the policy and pod after the test case
+			defer cleanup(tc.pod.Name, tc.policy.Name)
+
+			_, err := tascl.Create(tc.policy)
+			if err != nil {
+				log.Print(err)
+			}
+			time.Sleep(time.Second * 5)
+			_, err = cl.CoreV1().Pods("default").Create(context.TODO(), tc.pod, metav1.CreateOptions{})
+			if err != nil {
+				log.Print(err)
+			}
+			time.Sleep(time.Second * 5)
+			p, _ := cl.CoreV1().Pods("default").Get(context.TODO(), tc.pod.Name, metav1.GetOptions{})
+			log.Print(p.Name)
+
+			if !reflect.DeepEqual(tc.want, p.Spec.NodeName) {
+				t.Errorf("expected: %v, got: %v", tc.want, p.Spec.NodeName)
+			}
+		})
+	}
+
+}
+
+func podForPolicy(podName, policyName string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+			Labels:    map[string]string{"telemetry-policy": policyName},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "test",
+					Image:   "busybox",
+					Command: []string{"/bin/sh", "-c", "sleep INF"},
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{"telemetry/scheduling": *resource.NewQuantity(1, resource.DecimalSI)},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cleanup(podName string, policyName string) {
+	if podName != "" {
+		err := cl.CoreV1().Pods("default").Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		if err != nil {
+			log.Print(err.Error())
+		}
+	}
+	err := tascl.Delete(policyName, &metav1.DeleteOptions{})
+	if err != nil {
+		log.Print(err.Error())
+	}
+}
+
+func waitForMetrics(timeout time.Duration) error {
+	t := time.Now().Add(timeout)
+	var failureMessage error
+	for time.Now().Before(t) {
+		m, err := cm.GetNodeMetric("filter1_metric")
+		if len(m) > 0 {
+			log.Printf("Metrics returned after %v: %v", t.Sub(time.Now()), m)
+			return nil
+		}
+		time.Sleep(2)
+		failureMessage = err
+	}
+	return errors.Wrap(failureMessage, "Request for custom metrics has timed out.")
+}
+
+// tasLog returns the log of the Telemetry Aware Scheduling pod as a string
+func tasLog() string {
+	lbls := metav1.LabelSelector{MatchLabels: map[string]string{"app": "tas"}}
+
+	pods, err := cl.CoreV1().Pods("default").List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(lbls.MatchLabels).String()})
+	if err != nil {
+		return "error in getting config"
+	}
+	if len(pods.Items) <= 0 {
+		return "Tas logs not found in API  to not be running"
+	}
+	pod := pods.Items[0]
+	podLogOpts := v1.PodLogOptions{}
+	req := cl.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+	podLogs, err := req.Stream(context.TODO())
+	if err != nil {
+		return "error in opening stream"
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "error in copy information from podLogs to buf"
+	}
+	str := buf.String()
+
+	return str
+
+}
+
+func getTASPolicy(name string, str string, metric string, operator string, target int64) *api.TASPolicy {
+	pol := &api.TASPolicy{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: api.TASPolicySpec{
+			Strategies: map[string]api.TASPolicyStrategy{
+				//Need to have a base deschedule to make the scheduleonmetric policy work correctly.
+				//TODO: This should be considered a bug.
+				str: {
+					PolicyName: name,
+					Rules: []api.TASPolicyRule{
+						{Metricname: metric, Operator: operator, Target: target},
+					},
+				},
+			},
+		},
+	}
+	if str != dontschedule.StrategyType {
+		pol.Spec.Strategies[dontschedule.StrategyType] =
+			api.TASPolicyStrategy{
+				PolicyName: "filter1",
+				Rules: []api.TASPolicyRule{
+					{Metricname: "filter1_metric", Operator: "Equals", Target: 2000000},
+				},
+			}
+	}
+	return pol
+}

--- a/.github/scripts/e2e_cleanup.sh
+++ b/.github/scripts/e2e_cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Remove any test artifacts created by tests
+set -o errexit
+
+root="$(dirname "$0")/../../"
+tmp_dir="${root:?}/tmp"
+
+echo "removing '${tmp_dir}'" 
+rm -rf --preserve-root "${tmp_dir:?}" 

--- a/.github/scripts/e2e_get_tools.sh
+++ b/.github/scripts/e2e_get_tools.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+
+root="$(dirname "$0")/../../"
+VERSION="v0.10.0"
+KIND_BINARY_URL="https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-$(uname)-amd64"
+K8_STABLE_RELEASE_URL="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
+
+HELM_STABLE_RELEASE_URL="https://get.helm.sh/helm-v3.5.4-linux-amd64.tar.gz"
+
+if [ ! -d "${root:?}/tmp/bin" ]; then
+    mkdir -p "${root:?}/tmp/bin"
+fi
+
+echo "retrieving kind"
+curl --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 60 -Lo "${root}/tmp/bin/kind" "${KIND_BINARY_URL}"
+chmod +x "${root}/tmp/bin/kind"
+
+echo "retrieving kubectl"
+curl -Lo "${root}/tmp/bin/kubectl" "https://storage.googleapis.com/kubernetes-release/release/$(curl -s ${K8_STABLE_RELEASE_URL})/tmp/bin/linux/amd64/kubectl"
+chmod +x "${root}/tmp/bin/kubectl"
+
+
+echo "retrieving helm"
+curl --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 60 -Lo "${root}/tmp/helm.tar.gz" "${HELM_STABLE_RELEASE_URL}" 
+tar -zxvf "${root}/tmp/helm.tar.gz" && mv linux-amd64/helm "${root}/tmp/bin/helm" && rm -rf linux-amd64
+chmod +x "${root}/tmp/bin/helm"

--- a/.github/scripts/e2e_setup_cluster.sh
+++ b/.github/scripts/e2e_setup_cluster.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+set -eo pipefail
+
+root="$(dirname "$0")/../../"
+export PATH="${PATH}:${root:?}/bin:${root:?}/tmp/bin"
+RETRY_MAX=10
+INTERVAL=10
+TIMEOUT=300
+APP_NAME="tasextender"
+APP_DOCKER_TAG="${APP_NAME}:latest"
+K8_ADDITIONS_PATH="${root}/.github/scripts/policies"
+TMP_DIR="${root}/tmp"
+CNIS_DAEMONSET_URL="https://raw.githubusercontent.com/intel/multus-cni/master/e2e/cni-install.yml"
+CNIS_NAME="cni-plugins"
+
+# create cluster CA and policy for Kubernetes Scheduler
+# CA cert & key along with will be mounted to control plane
+# path /etc/kubernetes/pki. Kubeadm will utilise generated CA cert/key as root
+# Kubernetes CA. Cert for scheduler/TAS will be signed by this CA
+generate_k8_scheduler_config_data() {
+  mkdir -p "${TMP_DIR}"
+  mount_dir="$(mktemp -q -p "${TMP_DIR}" -d -t tas-e2e-k8-XXXXXXXX)"
+  cp "${K8_ADDITIONS_PATH}/policy.yaml" "${mount_dir}/"
+}
+
+create_cluster() {
+  [ -z "${mount_dir}" ] && echo "### no mount directory set" && exit 1
+  # deploy cluster with kind
+  cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  scheduler:
+    dnsPolicy: ClusterFirstWithHostNet
+    extraArgs:
+      config: /etc/kubernetes/policy/policy.yaml
+    extraVolumes:
+    - name: kubeconfig
+      hostPath: /etc/kubernetes/scheduler.conf
+      mountPath: /etc/kubernetes/scheduler.conf 
+    - name: certs 
+      hostPath: /etc/kubernetes/pki/
+      mountPath: /etc/kubernetes/pki/
+    - name: schedulerconfig
+      hostPath: /etc/kubernetes/policy/policy.yaml
+      mountPath: /etc/kubernetes/policy/policy.yaml
+nodes:
+  - role: control-plane
+    extraMounts:
+    - hostPath: "${mount_dir:?}"
+      containerPath: "/etc/kubernetes/policy/"
+  - role: worker
+    extraMounts:
+    - hostPath: "${mount_dir}/node1"
+      containerPath: "/tmp/node-metrics/node1.prom"
+      propagation: HostToContainer
+  - role: worker
+    extraMounts:
+    - hostPath: "${mount_dir}/node2"
+      containerPath: "/tmp/node-metrics/node2.prom"
+      propagation: HostToContainer
+  - role: worker
+    extraMounts:
+    - hostPath: "${mount_dir}/node3"
+      containerPath: "/tmp/node-metrics/node3.prom"
+      propagation: HostToContainer
+
+EOF
+}
+
+retry() {
+  local status=0
+  local retries=${RETRY_MAX:=5}
+  local delay=${INTERVAL:=5}
+  local to=${TIMEOUT:=20}
+  cmd="$*"
+
+  while [ $retries -gt 0 ]
+  do
+    status=0
+    timeout $to bash -c "echo $cmd && $cmd" || status=$?
+    if [ $status -eq 0 ]; then
+      break;
+    fi
+    echo "Exit code: '$status'. Sleeping '$delay' seconds before retrying"
+    sleep "$delay"
+    retries=$((retries-1))
+  done
+  return $status
+}
+
+check_requirements() {
+  for cmd in docker kind openssl kubectl base64; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "$cmd is not available"
+      exit 1
+    fi
+  done
+}
+
+echo "## checking requirements"
+check_requirements
+# generate K8 API server CA key/cert and supporting files for mTLS with NRI
+echo "## generating K8s scheduler config"
+generate_k8_scheduler_config_data
+
+
+echo "## copy node metrics files to mount path"
+cp "${K8_ADDITIONS_PATH}/node1" "${mount_dir}"
+cp "${K8_ADDITIONS_PATH}/node2" "${mount_dir}"
+cp "${K8_ADDITIONS_PATH}/node3" "${mount_dir}"
+
+
+echo "## start Kind cluster with precreated CA key/cert"
+create_cluster
+
+
+
+kubectl create namespace monitoring;
+helm install node-exporter "${root}/telemetry-aware-scheduling/deploy/charts/prometheus_node_exporter_helm_chart/";
+
+
+helm install prometheus "${root}/telemetry-aware-scheduling/deploy/charts/prometheus_helm_chart/";
+docker exec kind-control-plane mkdir -p /tmp/node-metrics/;
+
+openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout  "${TMP_DIR}/serving-ca.key" -out "${TMP_DIR}/serving-ca.crt" -subj "/CN=ca";
+kubectl create namespace custom-metrics ;kubectl -n custom-metrics create secret tls cm-adapter-serving-certs --cert="${TMP_DIR}/serving-ca.crt" --key="${TMP_DIR}/serving-ca.key";
+helm install prometheus-adapter "${root}/telemetry-aware-scheduling/deploy/charts/prometheus_custom_metrics_helm_chart/"
+
+echo "## build TAS"
+retry make build
+retry make image
+echo "## load TAS image into Kind"
+kind load docker-image "${APP_DOCKER_TAG}"
+
+echo "## config for kube-scheduler dns"
+docker cp  kind-control-plane:/etc/kubernetes/manifests/kube-scheduler.yaml  "${TMP_DIR}/kube-scheduler.yaml" 
+
+sed -e "/spec/a\\
+  dnsPolicy: ClusterFirstWithHostNet" "${TMP_DIR}/kube-scheduler.yaml" -i
+
+
+docker cp "${TMP_DIR}/kube-scheduler.yaml" kind-control-plane:/etc/kubernetes/manifests/kube-scheduler.yaml
+echo "## install coreDNS"
+kubectl -n kube-system wait --for=condition=available deploy/coredns --timeout=300s
+echo "## install CNIs"
+retry kubectl create -f "${CNIS_DAEMONSET_URL}"
+retry kubectl -n kube-system wait --for=condition=ready -l name="${CNIS_NAME}" pod --timeout=300s
+
+
+mkdir "${mount_dir}/certs"
+docker cp kind-control-plane:/etc/kubernetes/pki/ca.crt "${mount_dir}/certs/client.crt"
+docker cp kind-control-plane:/etc/kubernetes/pki/ca.key "${mount_dir}/certs/client.key"
+
+
+kubectl create secret tls extender-secret --cert "${mount_dir}/certs/client.crt" --key "${mount_dir}/certs/client.key"
+kubectl apply -f "${root}/telemetry-aware-scheduling/deploy/"

--- a/.github/scripts/e2e_teardown_cluster.sh
+++ b/.github/scripts/e2e_teardown_cluster.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Teardown Kind cluster
+
+root="$(dirname "$0")/../../"
+export PATH="${PATH}:${root:?}/tmp/bin"
+
+if ! command -v kind &> /dev/null; then
+  echo "kind is not available. Run 'make e2e' first"
+  exit 1
+fi
+
+kind delete cluster

--- a/.github/scripts/policies/node1
+++ b/.github/scripts/policies/node1
@@ -1,0 +1,3 @@
+node_filter1_metric 10
+node_filter2_metric 0
+node_prioritize1_metric 1000

--- a/.github/scripts/policies/node2
+++ b/.github/scripts/policies/node2
@@ -1,0 +1,4 @@
+node_filter1_metric 20
+node_filter2_metric 0
+node_prioritize1_metric 9999
+node_deschedule1_metric 9

--- a/.github/scripts/policies/node3
+++ b/.github/scripts/policies/node3
@@ -1,0 +1,5 @@
+node_filter1_metric 10
+node_filter2_metric 0
+node_prioritize1_metric 0
+
+

--- a/.github/scripts/policies/policy.yaml
+++ b/.github/scripts/policies/policy.yaml
@@ -1,0 +1,26 @@
+    {
+        "kind" : "KubeSchedulerConfiguration",
+        "apiVersion" : "kubescheduler.config.k8s.io/v1beta1",
+        "clientConnection": {
+           "kubeconfig": "/etc/kubernetes/scheduler.conf"
+        },
+        "extenders" : [
+            {
+              "urlPrefix": "https://tas-service.default.svc.cluster.local:9001",             
+              "prioritizeVerb": "scheduler/prioritize",
+              "filterVerb": "scheduler/filter",
+              "weight": 100,
+              "managedResources": [
+                   {
+                     "name": "telemetry/scheduling",
+                     "ignoredByScheduler": true
+                   }
+              ],
+              "tlsConfig": {
+                     "insecure": true,
+                     "certFile": "/etc/kubernetes/pki/ca.crt",
+                     "keyFile" : "/etc/kubernetes/pki/ca.key"
+              }
+            }
+           ]
+    }

--- a/.github/workflows/end-to-end-test.yaml
+++ b/.github/workflows/end-to-end-test.yaml
@@ -1,0 +1,20 @@
+name: End to end tests
+
+on: [push, pull_request]
+
+jobs:
+  end-to-end-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go version
+        uses: actions/setup-go@v1
+        with:
+         go-version: 1.13
+      - name: Get tools for cluster installation
+        run: ./.github/scripts/e2e_get_tools.sh
+      - name: Set up cluster with TAS and custom metrics
+        run: ./.github/scripts/e2e_setup_cluster.sh
+      - name: Run end to end tests
+        run: go test -v ./.github/e2e/e2e_test.go


### PR DESCRIPTION
End to end tests for the prioritize filter and deschedule
strategies of TAS are used here as basic smoke tests to ensure the
scheduler is operating in basic good order as intended. These
tests are designed for basic regression on new changes, but the
framework, based on the Kubernetes in Docker set up, can be used
for more extensive and specific end to end testing.
