### PR TITLE
Fix bug in adding and deleting many strategies quickly

### DIFF
--- a/.github/e2e/e2e_test.go
+++ b/.github/e2e/e2e_test.go
@@ -197,6 +197,19 @@ func TestTASPrioritize(t *testing.T) {
 
 }
 
+func repeatTest (f func(*testing.T), t *testing.T,reps int) {
+	for i:= 0 ; i<= reps ; i++ {
+		f(t)
+	}
+}
+
+
+//TestAddAndDeletePolicy repeats a test to show an issue in repeatedly adding and deleting policies
+func TestAddAndDeletePolicy(t *testing.T) {
+	repeatTest(TestTASFilter, t, 5)
+}
+
+
 func podForPolicy(podName, policyName string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -265,7 +278,12 @@ func tasLog() string {
 	if err != nil {
 		return "error in opening stream"
 	}
-	defer podLogs.Close()
+	defer func() {
+		err := podLogs.Close()
+		if err != nil {
+			log.Print("error in closing log stream")
+		}
+	}()
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating.go
@@ -91,7 +91,7 @@ func (n *AutoUpdatingCache) ReadPolicy(namespace string, policyName string) (tel
 	if policy, ok := value.(telemetrypolicy.TASPolicy); ok {
 		return policy, nil
 	}
-	return telemetrypolicy.TASPolicy{}, errors.New("no policy of this name found")
+	return telemetrypolicy.TASPolicy{}, errors.New("no policy " + policyName+" found")
 }
 
 //WritePolicy sends the passed object to be stored in the cache under the namespace/name

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating.go
@@ -91,7 +91,7 @@ func (n *AutoUpdatingCache) ReadPolicy(namespace string, policyName string) (tel
 	if policy, ok := value.(telemetrypolicy.TASPolicy); ok {
 		return policy, nil
 	}
-	return telemetrypolicy.TASPolicy{}, errors.New("no policy " + policyName+" found")
+	return telemetrypolicy.TASPolicy{}, errors.New("no policy " + policyName + " found")
 }
 
 //WritePolicy sends the passed object to be stored in the cache under the namespace/name

--- a/telemetry-aware-scheduling/pkg/controller/controller.go
+++ b/telemetry-aware-scheduling/pkg/controller/controller.go
@@ -65,7 +65,7 @@ func (controller *TelemetryPolicyController) onAdd(obj interface{}) {
 		klog.V(2).InfoS("Policy not added to cache: "+err.Error(), "component", "controller")
 		return
 	}
-	for _, name := range controller.Enforcer.RegisteredStrategyTypes() {
+	for name := range polCopy.Spec.Strategies {
 		klog.V(4).InfoS("registering "+name+" from "+pol.Name, "component", "controller")
 		strt, err := castStrategy(name, polCopy.Spec.Strategies[name])
 		if err != nil {
@@ -114,7 +114,7 @@ func (controller *TelemetryPolicyController) onUpdate(old, new interface{}) {
 		return
 	}
 	klog.V(2).InfoS("Policy: "+polCopy.Name+" updated", "component", "controller")
-	for _, name := range controller.Enforcer.RegisteredStrategyTypes() {
+	for name := range polCopy.Spec.Strategies {
 		oldStrat, err := castStrategy(name, oldPol.Spec.Strategies[name])
 		if err != nil {
 			klog.V(2).InfoS(err.Error(), "component", "controller")
@@ -147,7 +147,7 @@ func (controller *TelemetryPolicyController) onUpdate(old, new interface{}) {
 func (controller *TelemetryPolicyController) onDelete(obj interface{}) {
 	pol := obj.(*telemetrypolicy.TASPolicy)
 	polCopy := pol.DeepCopy()
-	for _, name := range controller.Enforcer.RegisteredStrategyTypes() {
+	for name := range polCopy.Spec.Strategies {
 		strt, err := castStrategy(name, polCopy.Spec.Strategies[name])
 		if err != nil {
 			klog.V(2).InfoS(err.Error(), "component", "controller")

--- a/telemetry-aware-scheduling/pkg/strategies/core/types.go
+++ b/telemetry-aware-scheduling/pkg/strategies/core/types.go
@@ -22,7 +22,6 @@ type Interface interface {
 type Enforcer interface {
 	RegisterStrategyType(strategy Interface)
 	UnregisterStrategyType(strategy Interface)
-	RegisteredStrategyTypes() []string
 	IsRegistered(string) bool
 	AddStrategy(Interface, string)
 	RemoveStrategy(Interface, string)


### PR DESCRIPTION
Add a test to show the issue with repeatedly adding and deleting a policy in TAS.
The test is implemented in the e2e package as a repeat of the TestTASFilter test.

This PR also contains a fix to the issue. Marking this as WIP until I understand the full mechanics of the intermittent bug and sure we have a fix here.