### PR TITLE
WIP: test scheduling with a scheduleonmetric only policy

### DIFF
--- a/.github/scripts/policies/node1
+++ b/.github/scripts/policies/node1
@@ -1,3 +1,5 @@
 node_filter1_metric 10
 node_filter2_metric 0
 node_prioritize1_metric 1000
+node_prioritize2_metric 1000
+

--- a/.github/scripts/policies/node2
+++ b/.github/scripts/policies/node2
@@ -1,4 +1,5 @@
 node_filter1_metric 20
 node_filter2_metric 0
 node_prioritize1_metric 9999
+node_prioritize2_metric 9999
 node_deschedule1_metric 9

--- a/.github/scripts/policies/node3
+++ b/.github/scripts/policies/node3
@@ -1,5 +1,7 @@
 node_filter1_metric 10
 node_filter2_metric 0
 node_prioritize1_metric 0
+node_prioritize2_metric 0
+
 
 

--- a/telemetry-aware-scheduling/pkg/telemetryscheduler/telemetryscheduler.go
+++ b/telemetry-aware-scheduling/pkg/telemetryscheduler/telemetryscheduler.go
@@ -188,8 +188,11 @@ func (m MetricsExtender) filterNodes(args extender.Args) *extender.FilterResult 
 	}
 	dontscheduleStrategy, err := m.getDontScheduleStrategy(policy)
 	if err != nil {
-		klog.V(2).InfoS("Don't scheduler strategy failed "+err.Error(), "component", "extender")
-		return nil
+		// If no dontschedulepolicy is found return the full list of nodes but log an error
+		klog.V(2).InfoS("Dontschedule strategy failed "+err.Error(), "component", "extender")
+		klog.V(2).InfoS("Returning unfiltered list of nodes for scheduling", "component", "extender")
+		result.Nodes = args.Nodes
+		return &result
 	}
 	violatingNodes := dontscheduleStrategy.Violated(m.cache)
 	if len(args.Nodes.Items) == 0 {


### PR DESCRIPTION
This change highlights and fixes an issue where error handling of the filter method in TAS can cause the scheduleonmetric strategy to fail. The first commit adds a test to show the failures pointed to in this TODO https://github.com/intel/platform-aware-scheduling/blob/48c2d0fe5b6e90e318da1cceeb03ae627e4b9b5c/.github/e2e/e2e_test.go#L288

Additional commits will be added to show the solution to the issue. There is a decision on error handling that needs to be made in order to enable this behaviour while keeping the other features of TAS as expected. 

This issue interacts with the handling of the error in #55 so no change should be merged until that change is merged. One issue is around the handling of adding policies and the registered strategy map which can create a perceivable delay in adding strategies to the cache. The solution in #55 of removing access to the RegisteredStrategies store could be part of the solution to this issue - but it will have to be thought of in combination with that issue. 