### PR TITLE
Add fix flagged by scope lints

### DIFF
--- a/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
@@ -34,6 +34,7 @@ func TestNodeMetricsCache_PeriodicUpdate(t *testing.T) {
 			metrics.TestNodeMetricCustomInfo([]string{"node A", "node B"}, []int64{500, 300}), true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			n := NewAutoUpdatingCache()
 			go n.PeriodicUpdate(*time.NewTicker(time.Second), tt.args.client, map[string]interface{}{})
@@ -79,6 +80,7 @@ func TestNodeMetricsCache_ReadMetric(t *testing.T) {
 		{"non existing metric", MockSelfUpdatingCache(), args{"non-existing metric"}, metrics.TestNodeMetricCustomInfo([]string{"node A", "node B"}, []int64{50, 30}), true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.n.ReadMetric(tt.args.metricName)
 			if err != nil {
@@ -109,6 +111,7 @@ func TestNodeMetricsCache_ReadPolicy(t *testing.T) {
 		{"non existing policy", MockSelfUpdatingCache(), args{mockPolicy}, mockPolicy2, true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err1 := tt.n.WritePolicy(tt.args.policy.Namespace, tt.args.policy.Name, mockPolicy)
 			got, err2 := tt.n.ReadPolicy(tt.want.Namespace, tt.want.Name)
@@ -144,6 +147,7 @@ func TestNodeMetricsCache_DeletePolicy(t *testing.T) {
 		{"delete non existing policy", MockSelfUpdatingCache(), args{mockPolicy}, mockPolicy2, false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_ = tt.n.WritePolicy(tt.args.policy.Namespace, tt.args.policy.Name, mockPolicy)
 			err2 := tt.n.DeletePolicy(tt.deleted.Namespace, tt.deleted.Name)
@@ -178,6 +182,7 @@ func TestNodeMetricsCache_WriteMetric(t *testing.T) {
 		{"add existing metric", MockEmptySelfUpdatingCache(), "dummyMetric1", args{"dummyMetric1"}, false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.n.WriteMetric(tt.args.metricName, nil)
 			if err != nil && !tt.errorExpected {
@@ -210,6 +215,7 @@ func TestNodeMetricsCache_DeleteMetric(t *testing.T) {
 		{"delete non-Existing Metric", MockSelfUpdatingCache(), args{"top speed"}, "dummyMetric1", true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, presentAtStart := tt.n.ReadMetric(tt.queriedMetric)
 			err := tt.n.DeleteMetric(tt.args.metricName)

--- a/telemetry-aware-scheduling/pkg/controller/controller_test.go
+++ b/telemetry-aware-scheduling/pkg/controller/controller_test.go
@@ -37,6 +37,7 @@ func TestTelemetryPolicyController_Run(t *testing.T) {
 		//},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			controller := &TelemetryPolicyController{
 				tt.fields.TelemetryPolicyClient,

--- a/telemetry-aware-scheduling/pkg/metrics/client_test.go
+++ b/telemetry-aware-scheduling/pkg/metrics/client_test.go
@@ -105,6 +105,7 @@ func Test_customMetricsClient_GetNodeMetric(t *testing.T) {
 		{"non existent metric query", fields{dm}, args{"nonExistentMetric"}, NodeMetricsInfo{}, true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := CustomMetricsClient{
 				tt.fields.client,
@@ -139,6 +140,7 @@ func TestNewClient(t *testing.T) {
 		{"valid config", args{dummyRestClientConfig()}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewClient(tt.args.config)
 			if reflect.TypeOf(got) != reflect.TypeOf(dummyRestClientConfig()) {

--- a/telemetry-aware-scheduling/pkg/strategies/core/enforcer_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/core/enforcer_test.go
@@ -24,6 +24,7 @@ func TestNewEnforcer(t *testing.T) {
 		// TODO: add test cases.
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewEnforcer(tt.args.kubeClient); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewEnforcer() = %v, want %v", got, tt.want)
@@ -50,6 +51,7 @@ func TestMetricEnforcer_RegisterStrategyType(t *testing.T) {
 		{"RegisterStrategyType one strategy", fields{make(map[string]map[Interface]interface{}), "violates", testclient.NewSimpleClientset()}, args{str: mockedStrategy}, []string{"mocko"}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredTypes,
@@ -86,6 +88,7 @@ func TestMetricEnforcer_UnregisterStrategyType(t *testing.T) {
 		{"RegisterStrategyType working", fields{make(map[string]map[Interface]interface{}), "violates", testclient.NewSimpleClientset()}, args{str: mockedStrategy}, []string{}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredTypes,
@@ -120,6 +123,7 @@ func TestMetricEnforcer_RegisteredStrategyTypes(t *testing.T) {
 		{"no strategies", fields{RegisteredTypes: map[string]map[Interface]interface{}{}, PodViolatingLabel: "", KubeClient: testclient.NewSimpleClientset()}, []string{}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredTypes,
@@ -157,6 +161,7 @@ func TestMetricEnforcer_AddStrategy(t *testing.T) {
 			args{str: mockedStrategy, strategyType: "mocko"}, map[string]Interface{"mocko": mockedStrategy}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredStrategies,
@@ -237,6 +242,7 @@ func TestMetricEnforcer_IsRegistered(t *testing.T) {
 			args{"not registered"}, false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredStrategies,
@@ -275,6 +281,7 @@ func TestMetricEnforcer_RemoveStrategy(t *testing.T) {
 			true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &MetricEnforcer{
 				RegisteredStrategies: tt.fields.RegisteredStrategies,

--- a/telemetry-aware-scheduling/pkg/strategies/core/operator_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/core/operator_test.go
@@ -40,6 +40,7 @@ func TestOperator(t *testing.T) {
 		{name: "Blank Operator", args: args{value: 100, rule: telemetrypolicy.TASPolicyRule{Metricname: "memory", Operator: "", Target: 1000}}, want: false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			num := *resource.NewQuantity(tt.args.value, resource.DecimalSI)
 			if got := EvaluateRule(num, tt.args.rule); got != tt.want {
@@ -63,6 +64,7 @@ func TestOrderedList(t *testing.T) {
 		{"greater than test", args{testNodeMetricCustomInfo([]string{"node A", "node B", "node C"}, []int64{100, 200, 10}), "GreaterThan"}, []NodeSortableMetric{{"node B", *resource.NewQuantity(200, resource.DecimalSI)}, {"node A", *resource.NewQuantity(100, resource.DecimalSI)}, {"node C", *resource.NewQuantity(10, resource.DecimalSI)}}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := OrderedList(tt.args.metricsInfo, tt.args.operator)
 			if !reflect.DeepEqual(got, tt.want) {

--- a/telemetry-aware-scheduling/pkg/strategies/deschedule/deschedule_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/deschedule/deschedule_test.go
@@ -53,6 +53,7 @@ func TestDeschedule_Cleanup(t *testing.T) {
 			want: []string{}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		nodeAction(t, tt, "create")
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.d.Cleanup(tt.args.enforcer, tt.d.PolicyName) //testing Cleanup()
@@ -88,6 +89,7 @@ func TestDeschedule_Relabel_nodes(t *testing.T) {
 			want: []string{"violating", "violating"}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		nodeAction(t, tt, "create")
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.d.Cleanup(tt.args.enforcer, tt.d.PolicyName) //testing Cleanup()

--- a/telemetry-aware-scheduling/pkg/strategies/deschedule/enforce_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/deschedule/enforce_test.go
@@ -49,6 +49,7 @@ func TestDescheduleStrategy_Enforce(t *testing.T) {
 			want: expected{nodeNames: []string{}}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1, Value: *resource.NewQuantity(100, resource.DecimalSI)}})
 		if err != nil {
 			t.Errorf("Cannot write metric to mock cach for test: %v", err)

--- a/telemetry-aware-scheduling/pkg/strategies/deschedule/strategy_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/deschedule/strategy_test.go
@@ -31,6 +31,7 @@ func TestDescheduleStrategy_SetPolicyName(t *testing.T) {
 		{name: "set basic name", d: &Strategy{}, args: args{"test policy"}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.d.SetPolicyName(tt.args.name)
 			if tt.d.PolicyName != tt.args.name {
@@ -49,6 +50,7 @@ func TestDescheduleStrategy_GetPolicyName(t *testing.T) {
 		{name: "retrieve basic name", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{}}, want: "test name"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.d.GetPolicyName(); got != tt.want {
 				t.Errorf("Strategy.GetPolicyName() = %v, want %v", got, tt.want)
@@ -76,6 +78,7 @@ func TestDescheduleStrategy_Equals(t *testing.T) {
 		{name: "Not equal different target", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 10}}}, args: args{other: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 50}}}}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.d.Equals(tt.args.other); got != tt.want {
 				a, _ := tt.args.other.(*Strategy)
@@ -102,6 +105,7 @@ func TestDescheduleStrategy_Violated(t *testing.T) {
 		{name: "No metric found", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "mem", Operator: "GreaterThan", Target: 9}}}, args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1, Value: *resource.NewQuantity(10, resource.DecimalSI)}})
 			if err != nil {
@@ -123,6 +127,7 @@ func TestDescheduleStrategy_StrategyType(t *testing.T) {
 		{name: "basic type", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{}}, want: "deschedule"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.d.StrategyType(); got != tt.want {
 				t.Errorf("Strategy.StrategyType() = %v, want %v", got, tt.want)

--- a/telemetry-aware-scheduling/pkg/strategies/dontschedule/strategy_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/dontschedule/strategy_test.go
@@ -29,6 +29,7 @@ func TestDontScheduleStrategy_Violated(t *testing.T) {
 		{name: "No metric found", d: Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "mem", Operator: "GreaterThan", Target: 9}}}, args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1, Value: *resource.NewQuantity(10, resource.DecimalSI)}})
 			if err != nil {
@@ -51,6 +52,7 @@ func TestDontScheduleStrategy_StrategyType(t *testing.T) {
 		{"get strategy type", Strategy{}, "dontschedule"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := Strategy{}
 			if got := d.StrategyType(); got != tt.want {
@@ -73,6 +75,7 @@ func TestDontScheduleStrategy_Equals(t *testing.T) {
 		{"simple equality test ", Strategy{}, args{&Strategy{}}, false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := Strategy{}
 			if got := d.Equals(tt.args.in0); got != tt.want {
@@ -91,6 +94,7 @@ func TestDontScheduleStrategy_GetPolicyName(t *testing.T) {
 		{"get name", Strategy{}, "demo-policy"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := Strategy{}
 			d.SetPolicyName("demo-policy")
@@ -116,6 +120,7 @@ func TestDontScheduleStrategy_Enforce(t *testing.T) {
 		{"simple enforce test", Strategy{}, args{&core.MetricEnforcer{}, &cache.AutoUpdatingCache{}}, 0, false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := Strategy{}
 			got, err := d.Enforce(tt.args.enforcer, tt.args.cache)

--- a/telemetry-aware-scheduling/pkg/telemetryscheduler/scheduler_test.go
+++ b/telemetry-aware-scheduling/pkg/telemetryscheduler/scheduler_test.go
@@ -112,6 +112,7 @@ func TestMetricsExtender_prescheduleChecks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewMetricsExtender(tt.fields.cache)
 			err := tt.fields.cache.WritePolicy(tt.fields.policy.Namespace, tt.fields.policy.Name, tt.fields.policy)
@@ -200,6 +201,7 @@ func TestMetricsExtender_Prioritize(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewMetricsExtender(tt.fields.cache)
 			err := tt.fields.cache.WritePolicy(tt.fields.policy.Namespace, tt.fields.policy.Name, tt.fields.policy)
@@ -292,6 +294,7 @@ func TestMetricsExtender_Filter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			m := MetricsExtender{
 				cache: tt.fields.cache,


### PR DESCRIPTION
This PR considers a fix for lints related to the scope, i.e., by using the variable on range scope tt in function literal.