### PR TITLE
labeling strategy

### DIFF
--- a/telemetry-aware-scheduling/cmd/main.go
+++ b/telemetry-aware-scheduling/cmd/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/deschedule"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/dontschedule"
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/labeling"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/scheduleonmetric"
 	telemetrypolicyclient "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/client/v1alpha1"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetryscheduler"
@@ -88,6 +89,7 @@ func tasController(kubeConfig string, syncPeriod string, cache *tascache.AutoUpd
 	enfrcr.RegisterStrategyType(&deschedule.Strategy{})
 	enfrcr.RegisterStrategyType(&scheduleonmetric.Strategy{})
 	enfrcr.RegisterStrategyType(&dontschedule.Strategy{})
+	enfrcr.RegisterStrategyType(&labeling.Strategy{})
 	go cont.Run(ctx)
 	go enfrcr.EnforceRegisteredStrategies(cache, *enforcerTicker)
 	done := make(chan os.Signal, 1)

--- a/telemetry-aware-scheduling/pkg/controller/controller.go
+++ b/telemetry-aware-scheduling/pkg/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	strategy "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/core"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/deschedule"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/dontschedule"
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/labeling"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/scheduleonmetric"
 	telemetrypolicy "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1"
 	core "k8s.io/api/core/v1"
@@ -101,6 +102,9 @@ func castStrategy(strategyType string, policy telemetrypolicy.TASPolicyStrategy)
 		return &str, nil
 	case dontschedule.StrategyType:
 		str := (dontschedule.Strategy)(policy)
+		return &str, nil
+	case labeling.StrategyType:
+		str := (labeling.Strategy)(policy)
 		return &str, nil
 	default:
 		return nil, errors.New("strategy could not be added - invalid strategy type")

--- a/telemetry-aware-scheduling/pkg/strategies/labeling/enforce.go
+++ b/telemetry-aware-scheduling/pkg/strategies/labeling/enforce.go
@@ -1,0 +1,291 @@
+package labeling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/cache"
+	strategy "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/core"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+const (
+	labelPrefix = "telemetry.aware.scheduling."
+)
+
+// node -> policy name -> labels slice (label is stored prefixed and the format is key=value).
+type violationMap map[string]map[string][]string
+
+// node -> all labels map (label is stored prefixed and the format is key=value).
+type nodeViolations map[string]map[string]bool
+
+type patchValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+func createLabelPatchValue(op, labelName, value string) *patchValue {
+	return &patchValue{
+		Op:    op,
+		Path:  "/metadata/labels/" + labelName,
+		Value: value,
+	}
+}
+
+func getPrefix(policyName string) string {
+	return labelPrefix + policyName + "/"
+}
+
+// Enforce describes the behavior followed by this strategy to return associated pods to non-violating status.
+// The labels can be used externally for different purposes, e.g. by a descheduler.
+// Here we make an api call to list all nodes first. This may be improved by using a controller instead or some
+// other way of not waiting for the API call every time Enforce is called.
+func (d *Strategy) Enforce(enforcer *strategy.MetricEnforcer, cache cache.Reader) (int, error) {
+	nodes, err := enforcer.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		msg := fmt.Sprintf("cannot list nodes: %v", err)
+		klog.V(2).InfoS(msg, "component", "controller")
+
+		return -1, fmt.Errorf("enforce failure (node list), %w", err)
+	}
+
+	violations, allNodeViolatedLabels := d.nodeStatusForStrategy(enforcer, cache)
+
+	numberViolations, err := d.updateNodeLabels(enforcer, violations, allNodeViolatedLabels, nodes)
+	if err != nil {
+		klog.V(2).InfoS(err.Error(), "component", "controller")
+
+		return -1, err
+	}
+
+	return numberViolations, nil
+}
+
+// patchNode takes a json patch value and sends it to the API server to patch a node. Here it's used to label nodes.
+func (d *Strategy) patchNode(nodeName string, enforcer *strategy.MetricEnforcer, payload []patchValue) error {
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		klog.V(4).InfoS(err.Error(), "component", "controller")
+
+		return fmt.Errorf("node patch marshaling failure: %w", err)
+	}
+
+	_, err = enforcer.KubeClient.CoreV1().Nodes().Patch(
+		context.TODO(), nodeName, types.JSONPatchType, jsonPayload, metav1.PatchOptions{})
+	if err != nil {
+		klog.V(4).InfoS(err.Error(), "component", "controller")
+
+		return fmt.Errorf("node patch failure: %w", err)
+	}
+
+	return nil
+}
+
+// appendViolationPatchValue appends a patch for either replacing a changed label or for adding a new one, if one
+// doesn't already exist. Returns the given payload slice appended by any needed patch value.
+// if label exists and the value has not changed, nothing is appended.
+func appendViolationPatchValue(payload []patchValue, label string, node *v1.Node) ([]patchValue, error) {
+	nameValuePair := strings.Split(label, "=")
+	if len(nameValuePair) != 2 {
+		return payload, errors.New("Invalid label, patch creation failed for: " + label)
+	}
+
+	labelName := nameValuePair[0]
+	oldValue, old := node.Labels[labelName]
+	op := "add"
+
+	if old {
+		op = "replace"
+	}
+
+	if labelValue := nameValuePair[1]; !old || oldValue != labelValue {
+		name := strings.ReplaceAll(labelName, "/", "~1")
+		klog.V(2).InfoS("patching for violation",
+			"old", old, "op", op, "name", name, "labelValue", labelValue, "oldValue", oldValue)
+
+		payload = append(payload, *createLabelPatchValue(op, name, labelValue))
+	}
+
+	return payload, nil
+}
+
+func appendNodeLabelCleanups(payload []patchValue, nodeViolatedLabels map[string]bool, node *v1.Node) []patchValue {
+	for labelName, labelValue := range node.Labels {
+		isViolatedLabel := nodeViolatedLabels[labelName+"="+labelValue]
+		if strings.HasPrefix(labelName, labelPrefix) && !isViolatedLabel {
+			name := strings.ReplaceAll(labelName, "/", "~1")
+			klog.V(2).InfoS("patching for cleanup", "name", name)
+			payload = append(payload, *createLabelPatchValue("remove", name, ""))
+		}
+	}
+
+	return payload
+}
+
+// updateNodeLabels takes the list of nodes violating the strategy. It then sets the payloads for labelling
+// them as violators and calls for them to be labelled.
+func (d *Strategy) updateNodeLabels(enforcer *strategy.MetricEnforcer,
+	violations violationMap, allNodesViolatedLabels nodeViolations, allNodes *v1.NodeList) (int, error) {
+	totalViolations := 0
+	labelErrs := ""
+
+	var errOut error
+
+	for _, node := range allNodes.Items {
+		node := node
+		payload := []patchValue{}
+		violatedPolicies := ""
+
+		for policyName, labels := range violations[node.Name] {
+			for _, label := range labels {
+				payload, errOut = appendViolationPatchValue(payload, label, &node)
+			}
+
+			if errOut != nil {
+				return -1, errOut
+			}
+
+			violatedPolicies += policyName + ", "
+			totalViolations++
+		}
+
+		payload = appendNodeLabelCleanups(payload, allNodesViolatedLabels[node.Name], &node)
+
+		if len(payload) > 0 {
+			klog.V(2).InfoS("Patching", "Payload:", payload)
+
+			err := d.patchNode(node.Name, enforcer, payload)
+			if err != nil {
+				klog.V(4).InfoS(err.Error(), "component", "controller")
+
+				labelErrs = labelErrs + node.Name + ": [ " + violatedPolicies + " ]; "
+			}
+		}
+
+		if len(violatedPolicies) > 0 {
+			klog.V(2).InfoS("Node "+node.Name+" violating "+violatedPolicies, "component", "controller")
+		}
+	}
+
+	if len(labelErrs) > 0 {
+		errOut = errors.New("could not label" + labelErrs)
+	}
+
+	return totalViolations, errOut
+}
+
+// minMaxFilterViolatedRules filters out violated rules in case the same label name is being used.
+// When the name is equal, only the largest or smallest value having metric among the rules will be
+// returned in the result map, depending on the operator of the rule.
+func minMaxFilterViolatedRules(violationResult interface{}) map[string]ruleResult {
+	violatedRules := map[string]ruleResult{}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			klog.Error("Unsupported config: With equivalent labels, the operator in related rules must also be equivalent.")
+		}
+	}()
+
+	for _, result := range violationResult.(*violationResultType).ruleResults {
+		for _, label := range result.rule.Labels {
+			nameValuePair := strings.Split(label, "=")
+			name := nameValuePair[0]
+			olderRes, old := violatedRules[name]
+
+			if old && olderRes.rule.Operator != result.rule.Operator {
+				log.Panic()
+			}
+
+			if !old || old && ((result.rule.Operator == "GreaterThan" && result.quantity.Cmp(olderRes.quantity) > 0) ||
+				(result.rule.Operator == "LessThan" && result.quantity.Cmp(olderRes.quantity) < 0)) {
+				violatedRules[name] = result
+			}
+		}
+	}
+
+	return violatedRules
+}
+
+// createLabels fills in labels to the given per-policy violation map and the flat map of all violated labels.
+func createLabels(violatedRules map[string]ruleResult,
+	nodeName, policyName string, violations violationMap, allViolatedLabels nodeViolations) {
+	for _, result := range violatedRules {
+		for _, label := range result.rule.Labels {
+			violations[nodeName][policyName] = append(violations[nodeName][policyName], getPrefix(policyName)+label)
+			allViolatedLabels[nodeName][getPrefix(policyName)+label] = true
+		}
+	}
+}
+
+// nodeStatusForStrategy returns violations as a slice of nodeName->policyName->[]label and
+// as a flat map of the nodeName->label->true for quick access searching.
+// Within same policy, overlapping label key values will go through min-max filtering, largest or smallest
+// value producing metric will get its label depending on rule operator. Unique label keys will always be
+// returned for the violating cases.
+func (d *Strategy) nodeStatusForStrategy(enforcer *strategy.MetricEnforcer,
+	cache cache.Reader) (violationMap, nodeViolations) {
+	violations := violationMap{}
+	allViolatedLabels := nodeViolations{}
+
+	for strategy := range enforcer.RegisteredStrategies[StrategyType] {
+		policyName := strategy.GetPolicyName()
+		klog.V(2).InfoS("Evaluating "+policyName, "component", "controller")
+
+		nodes := strategy.Violated(cache)
+
+		for nodeName, violationResult := range nodes {
+			if _, ok := violations[nodeName]; !ok {
+				violations[nodeName] = map[string][]string{}
+			}
+
+			if _, ok := allViolatedLabels[nodeName]; !ok {
+				allViolatedLabels[nodeName] = map[string]bool{}
+			}
+
+			violatedRules := minMaxFilterViolatedRules(violationResult)
+			createLabels(violatedRules, nodeName, policyName, violations, allViolatedLabels)
+		}
+	}
+
+	return violations, allViolatedLabels
+}
+
+// Cleanup remove node labels for violating when policy is deleted.
+func (d *Strategy) Cleanup(enforcer *strategy.MetricEnforcer, policyName string) error {
+	nodes, err := enforcer.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		msg := fmt.Sprintf("cannot list nodes: %v", err)
+		klog.V(2).InfoS(msg, "component", "controller")
+
+		return fmt.Errorf("Cleanup failure: %w", err)
+	}
+
+	for _, node := range nodes.Items {
+		for labelName := range node.Labels {
+			name := strings.ReplaceAll(labelName, "/", "~1")
+
+			var payload []patchValue
+			if strings.HasPrefix(labelName, getPrefix(policyName)) {
+				payload = append(payload, *createLabelPatchValue("remove", name, ""))
+			}
+
+			err := d.patchNode(node.Name, enforcer, payload)
+			if err != nil {
+				klog.V(2).InfoS(err.Error(), "component", "controller")
+			}
+		}
+	}
+
+	klog.V(2).InfoS(fmt.Sprintf("Remove the node label on policy %v deletion", policyName), "component", "controller")
+
+	return nil
+}

--- a/telemetry-aware-scheduling/pkg/strategies/labeling/enforce_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/labeling/enforce_test.go
@@ -1,0 +1,409 @@
+package labeling
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/cache"
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/metrics"
+	strategy "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/core"
+	telpol "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
+)
+
+func TestLabelingStrategy_Enforce(t *testing.T) {
+	type args struct {
+		enforcer *strategy.MetricEnforcer
+		cache    cache.ReaderWriter
+	}
+	type expected struct {
+		nodeNames  []string
+		nodeLabels map[string]string
+	}
+	tests := []struct {
+		name    string
+		d       *Strategy
+		node    *v1.Node
+		args    args
+		wantErr bool
+		want    expected
+	}{ // this should test the labeling capacity on the node with metric that violates the labeling strategy rule.
+		{name: "node labelled",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 99, Labels: []string{"gpu-card1=false"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-card1": "false"}}},
+		// this should test no label added
+		{name: "node unlabeled test",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 3000, Labels: []string{"gpu-card0=false"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test two labels added
+		{name: "node labelled two different metrics",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 99, Labels: []string{"gpu-card1=false"}},
+					{Metricname: "cpu", Operator: "GreaterThan", Target: 10, Labels: []string{"gpu-card2=true"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-card1": "false",
+				"telemetry.aware.scheduling.labeling-test/gpu-card2": "true"}}},
+
+		// this should test single label preferred added by the minmax
+		// same label key: gpu-device - metric "memory" > "cpu"
+		{name: "node single labelled: -different metrics -same op, tag, and label key",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 100, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "GreaterThan", Target: 100, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-device": "card0"}}},
+
+		// this should test single label preferred added by the minmax
+		// same label key: gpu-device - metric "memory" < "cpu"
+		{name: "node single labelled: -different metrics -same op, tag, and label key",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "LessThan", Target: 10000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "LessThan", Target: 10000, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-device": "card1"}}},
+
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card1"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card0"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-device": "card1"}}},
+
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-device": "card0"}}},
+
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{"telemetry.aware.scheduling.labeling-test/gpu-device": "card0"}}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(2000, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		err = tt.args.cache.WriteMetric("cpu", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		_, err = tt.args.enforcer.KubeClient.CoreV1().Nodes().Create(context.TODO(), tt.node, metav1.CreateOptions{})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		tt.args.enforcer.RegisterStrategyType(tt.d)
+		tt.args.enforcer.AddStrategy(tt.d, tt.d.StrategyType())
+
+		t.Run(tt.name, func(t *testing.T) {
+			got := []string{}
+			tmp := map[string]string{}
+			_, err := tt.d.Enforce(tt.args.enforcer, tt.args.cache)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Strategy.Enforce() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			nodys, _ := tt.args.enforcer.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			for _, node := range nodys.Items {
+				tmp = node.Labels
+				got = append(got, node.Name)
+			}
+			if len(got) != len(tt.want.nodeNames) {
+				t.Errorf("Nodes returned: %v not as expected: %v", got, tt.want.nodeNames)
+			}
+			if len(tmp) != len(tt.want.nodeLabels) {
+				t.Errorf("Number of labels returned: %v not as expected: %v", len(tmp), len(tt.want.nodeLabels))
+			}
+			if !reflect.DeepEqual(tmp, tt.want.nodeLabels) {
+				t.Errorf("labels returned: %v not as expected: %v", tmp, tt.want.nodeLabels)
+			}
+		})
+	}
+}
+
+func TestLabelingStrategy_Enforce_unsupportedCases(t *testing.T) {
+	type args struct {
+		enforcer *strategy.MetricEnforcer
+		cache    cache.ReaderWriter
+	}
+	type expected struct {
+		nodeNames  []string
+		nodeLabels map[string]string
+	}
+	tests := []struct {
+		name    string
+		d       *Strategy
+		node    *v1.Node
+		args    args
+		wantErr bool
+		want    expected
+	}{
+		{name: "node not supported label: -different metrics and op, same tag and label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 200, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "LessThan", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		{name: "node not supported label: -different metrics, op, and tag - The same label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "LessThan", Target: 2000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		{name: "node not supported label: -different metrics, and tag - the same label keys",
+			d: &Strategy{
+				PolicyName: "labeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 20, Labels: []string{"gpu-device=card1"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card0"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.labeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cache for test: %v", err)
+		}
+		err = tt.args.cache.WriteMetric("cpu", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cache for test: %v", err)
+		}
+		_, err = tt.args.enforcer.KubeClient.CoreV1().Nodes().Create(context.TODO(), tt.node, metav1.CreateOptions{})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cache for test: %v", err)
+		}
+		tt.args.enforcer.RegisterStrategyType(tt.d)
+		tt.args.enforcer.AddStrategy(tt.d, tt.d.StrategyType())
+
+		t.Run(tt.name, func(t *testing.T) {
+			got := []string{}
+			tmp := map[string]string{}
+			klog.Info(tmp)
+			_, err := tt.d.Enforce(tt.args.enforcer, tt.args.cache)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Strategy.Enforce() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			nodys, _ := tt.args.enforcer.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			for _, node := range nodys.Items {
+				tmp = node.Labels
+				got = append(got, node.Name)
+			}
+			if len(got) != len(tt.want.nodeNames) {
+				t.Errorf("Nodes returned: %v not as expected: %v", got, tt.want.nodeNames)
+			}
+			if len(tmp) != len(tt.want.nodeLabels) {
+				t.Errorf("Number of labels returned: %v not as expected: %v", len(tmp), len(tt.want.nodeLabels))
+			}
+			if !reflect.DeepEqual(tmp, tt.want.nodeLabels) {
+				t.Errorf("labels returned: %v not as expected: %v", tmp, tt.want.nodeLabels)
+			}
+		})
+	}
+}
+
+func TestLabelingStrategy_Cleanup(t *testing.T) {
+	type args struct {
+		enforcer *strategy.MetricEnforcer
+		cache    cache.ReaderWriter
+	}
+	type expected struct {
+		nodeNames  []string
+		nodeLabels map[string]string
+	}
+	tests := []struct {
+		name    string
+		d       *Strategy
+		node    *v1.Node
+		args    args
+		wantErr bool
+		want    expected
+	}{ // this should test the labeling capacity on the node with metric that violates the labeling strategy rule.
+		{name: "node labelled then unlabelled",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 99, Labels: []string{"gpu-card1=false"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test no label added and no label removed from the policy
+		{name: "node unlabeled test",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 3000, Labels: []string{"gpu-card0=false"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test two labels added and both removed after cleanup
+		{name: "node labelled two different metrics",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 99, Labels: []string{"gpu-card1=false"}},
+					{Metricname: "cpu", Operator: "GreaterThan", Target: 10, Labels: []string{"gpu-card2=true"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test label removal on single label preferred added by the minmax
+		{name: "node single labelled: -different metrics -same op, tag, and label key",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "GreaterThan", Target: 100, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "GreaterThan", Target: 100, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test removal of the single label preferred added by the minmax
+		{name: "node single labelled: -different metrics -same op, tag, and label key",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "LessThan", Target: 10000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "LessThan", Target: 10000, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test removal of the single label preferred added by the minmax
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card1"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card0"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test removal of the single label preferred added by the minmax
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+
+		// this should test removal of the single label preferred added by the minmax
+		{name: "node single labelled: -different metrics and tag, same op and label keys",
+			d: &Strategy{
+				PolicyName: "unlabeling-test",
+				Rules: []telpol.TASPolicyRule{
+					{Metricname: "memory", Operator: "Equals", Target: 2000, Labels: []string{"gpu-device=card0"}},
+					{Metricname: "cpu", Operator: "Equals", Target: 200, Labels: []string{"gpu-device=card1"}}}},
+			node: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"telemetry.aware.scheduling.unlabeling-test": ""}}},
+			args: args{enforcer: strategy.NewEnforcer(testclient.NewSimpleClientset()), cache: cache.MockEmptySelfUpdatingCache()},
+			want: expected{nodeNames: []string{"node-1"}, nodeLabels: map[string]string{}}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(2000, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		err = tt.args.cache.WriteMetric("cpu", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+			Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		_, err = tt.args.enforcer.KubeClient.CoreV1().Nodes().Create(context.TODO(), tt.node, metav1.CreateOptions{})
+		if err != nil {
+			t.Errorf("Cannot write metric to mock cach for test: %v", err)
+		}
+		tt.args.enforcer.RegisterStrategyType(tt.d)
+		tt.args.enforcer.AddStrategy(tt.d, tt.d.StrategyType())
+
+		t.Run(tt.name, func(t *testing.T) {
+			got := []string{}
+			tmp := map[string]string{}
+			_, err := tt.d.Enforce(tt.args.enforcer, tt.args.cache)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Strategy.Enforce() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			err = tt.d.Cleanup(tt.args.enforcer, tt.d.PolicyName) // testing Cleanup()
+			if err != nil {
+				klog.InfoS(err.Error(), "component", "testing")
+			}
+			nodys, _ := tt.args.enforcer.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			for _, node := range nodys.Items {
+				tmp = node.Labels
+				got = append(got, node.Name)
+			}
+			if len(got) != len(tt.want.nodeNames) {
+				t.Errorf("Nodes returned: %v not as expected: %v", got, tt.want.nodeNames)
+			}
+			if len(tmp) != len(tt.want.nodeLabels) {
+				t.Errorf("Number of labels returned: %v not as expected: %v", len(tmp), len(tt.want.nodeLabels))
+			}
+			if !reflect.DeepEqual(tmp, tt.want.nodeLabels) {
+				t.Errorf("labels returned: %v not as expected: %v", tmp, tt.want.nodeLabels)
+			}
+		})
+	}
+}

--- a/telemetry-aware-scheduling/pkg/strategies/labeling/strategy.go
+++ b/telemetry-aware-scheduling/pkg/strategies/labeling/strategy.go
@@ -1,0 +1,140 @@
+// Package labeling provides the labeling strategy. Violation conditions and enforcement behavior are defined here.
+// When a node is violating the labeling strategy, the enforcer labels it as violating according to the policy label.
+// This label can then be used externally to act on the strategy violation.
+package labeling
+
+import (
+	"fmt"
+
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/cache"
+	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/core"
+	telempol "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+)
+
+// StrategyType is set to "labeling".
+const (
+	StrategyType = "labeling"
+)
+
+// Strategy type for labeling from a single policy.
+type Strategy telempol.TASPolicyStrategy
+
+// StrategyType returns the name of the strategy type. This is used to place it in the registry.
+func (d *Strategy) StrategyType() string {
+	return StrategyType
+}
+
+type ruleResult struct {
+	rule     telempol.TASPolicyRule
+	quantity resource.Quantity
+}
+
+type violationResultType struct {
+	ruleResults []ruleResult
+}
+
+// Violated checks if the strategy is violated by searching for nodes that have metrics that don't accord with
+// the target in labeling strategy.
+// Returns a map of nodeNames as key with a slice of violated rules and metric quantities in the result type.
+func (d *Strategy) Violated(cache cache.Reader) map[string]interface{} {
+	violatingNodes := map[string]interface{}{}
+
+	for _, rule := range d.Rules {
+		nodeMetrics, err := cache.ReadMetric(rule.Metricname)
+		if err != nil {
+			klog.V(2).InfoS(err.Error(), "component", "controller")
+
+			continue
+		}
+
+		for nodeName, nodeMetric := range nodeMetrics {
+			msg := fmt.Sprint(nodeName+" "+rule.Metricname, " = ", nodeMetric.Value.AsDec())
+			klog.V(4).InfoS(msg, "component", "controller")
+
+			if core.EvaluateRule(nodeMetric.Value, rule) {
+				msg := fmt.Sprintf(nodeName + " violating " + d.PolicyName + ": " + ruleToString(rule))
+				klog.V(2).InfoS(msg, "component", "controller")
+
+				if _, ok := violatingNodes[nodeName]; !ok {
+					violatingNodes[nodeName] = &violationResultType{}
+				}
+
+				res, ok := violatingNodes[nodeName].(*violationResultType)
+				if !ok {
+					klog.Error("unexpected type")
+
+					continue
+				}
+
+				res.ruleResults = append(res.ruleResults, ruleResult{rule: rule, quantity: nodeMetric.Value})
+				if len(res.ruleResults) > 0 {
+					for _, ruleRes := range res.ruleResults {
+						klog.V(2).Infof("Violated rules: %v", ruleToString(ruleRes.rule))
+					}
+				}
+			}
+		}
+	}
+
+	return violatingNodes
+}
+
+// ruleToString returns the rule passed to it as a single string.
+func ruleToString(rule telempol.TASPolicyRule) string {
+	return fmt.Sprintf("%v %v %v %v", rule.Metricname, rule.Operator, rule.Target, rule.Labels)
+}
+
+func equalRules(a, b *telempol.TASPolicyRule) bool {
+	if a.Metricname != b.Metricname {
+		return false
+	}
+
+	if a.Target != b.Target {
+		return false
+	}
+
+	if a.Operator != b.Operator {
+		return false
+	}
+
+	for j := range a.Labels {
+		if a.Labels[j] != b.Labels[j] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equals checks if a strategy is the same as the passed strategy.
+// It can be used to prevent duplication of strategies in the API and is also used to find strategies for deletion.
+// TODO: Remedial action if equal, i.e. point to other strategies. Make method order ambivalent.
+func (d *Strategy) Equals(other core.Interface) bool {
+	otherLabelingStrategy, ok := other.(*Strategy)
+
+	sameName := other.GetPolicyName() == d.GetPolicyName()
+	if ok && sameName && len(d.Rules) > 0 && len(d.Rules) == len(otherLabelingStrategy.Rules) {
+		for i, rule := range d.Rules {
+			rule := rule
+			if !equalRules(&rule, &otherLabelingStrategy.Rules[i]) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// GetPolicyName returns the name of the policy that originated strategy.
+func (d *Strategy) GetPolicyName() string {
+	return d.PolicyName
+}
+
+// SetPolicyName adds a policy name to be associated with this strategy.
+func (d *Strategy) SetPolicyName(name string) {
+	d.PolicyName = name
+}

--- a/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1/types.go
+++ b/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1/types.go
@@ -1,18 +1,18 @@
-//Package v1alpha1 describes the structure of the Telemetry Policy CRD.
+// Package v1alpha1 describes the structure of the Telemetry Policy CRD.
 package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//Defines key values for policy CRD
+// Defines key values for policy CRD.
 const (
 	Plural  = "taspolicies"
 	Group   = "telemetry.intel.com"
 	Version = "v1alpha1"
 )
 
-// TASPolicy is the Schema for the taspolicies API
+// TASPolicy is the Schema for the taspolicies API.
 type TASPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -21,30 +21,31 @@ type TASPolicy struct {
 	Status TASPolicyStatus `json:"status,omitempty"`
 }
 
-//TASPolicyStrategy contains a set of TASPolicyRule which define the strategy.
+// TASPolicyStrategy contains a set of TASPolicyRule which define the strategy.
 type TASPolicyStrategy struct {
 	PolicyName string          `json:"policyName"`
 	Rules      []TASPolicyRule `json:"rules"`
 }
 
-//TASPolicyRule contains specific, implementable logic of a metric name, an operator and a target.
+// TASPolicyRule contains the parameters for the strategy rule.
 type TASPolicyRule struct {
-	Metricname string `json:"metricname"`
-	Operator   string `json:"operator"`
-	Target     int64  `json:"target"`
+	Metricname string   `json:"metricname"`
+	Operator   string   `json:"operator"`
+	Target     int64    `json:"target"`
+	Labels     []string `json:"labels,omitempty"`
 }
 
-//TASPolicySpec is a map of strategies indexed by their strategy type name i.e. scheduleonmetric, dontschedule.
+// TASPolicySpec is a map of strategies indexed by their strategy type name i.e. scheduleonmetric, dontschedule.
 type TASPolicySpec struct {
 	Strategies map[string]TASPolicyStrategy `json:"strategies"`
 }
 
 // TASPolicyStatus defines the observed state of TASpolicy. Currently no status object is implemented.
-//TODO: Implement policy status object
+// TODO: Implement policy status object.
 type TASPolicyStatus struct {
 }
 
-//TASPolicyList contains a list of TASpolicy
+// TASPolicyList contains a list of TASpolicy.
 type TASPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This introduces a multi-rule labeling strategy which allows creating
per-metric policy-configurable node labels with metric target
values. Multiple labels can be created for each rule.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>