### PR TITLE
fix labeling CR validation

### DIFF
--- a/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
@@ -45,6 +45,10 @@ spec:
                            target:
                              format: int64
                              type: integer
+                           labels:
+                             type: array
+                             items:
+                               type: string
                          required:
                            - metricname
                            - operator


### PR DESCRIPTION
CRD properties for the labeling strategy were missing. This fixes
the bug.

Co-authored-by: vrantala <valtteri.rantala@intel.com>
Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>