### PR TITLE
Update tas deployment by pulling external image

### DIFF
--- a/.github/scripts/e2e_get_tools.sh
+++ b/.github/scripts/e2e_get_tools.sh
@@ -2,7 +2,7 @@
 set -o errexit
 
 root="$(dirname "$0")/../../"
-VERSION="v0.10.0"
+VERSION="v0.11.1"
 KIND_BINARY_URL="https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-$(uname)-amd64"
 K8_STABLE_RELEASE_URL="https://storage.googleapis.com/kubernetes-release/release/stable.txt"
 

--- a/.github/scripts/e2e_setup_cluster.sh
+++ b/.github/scripts/e2e_setup_cluster.sh
@@ -26,7 +26,7 @@ generate_k8_scheduler_config_data() {
 create_cluster() {
   [ -z "${mount_dir}" ] && echo "### no mount directory set" && exit 1
   # deploy cluster with kind
-  cat <<EOF | kind create cluster --config=-
+  cat <<EOF | kind create cluster --image kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
@@ -156,4 +156,5 @@ docker cp kind-control-plane:/etc/kubernetes/pki/ca.key "${mount_dir}/certs/clie
 
 
 kubectl create secret tls extender-secret --cert "${mount_dir}/certs/client.crt" --key "${mount_dir}/certs/client.key"
+sed "s/intel\/telemetry-aware-scheduling/tasextender/g" "${root}/telemetry-aware-scheduling/deploy/tas-deployment.yaml" -i
 kubectl apply -f "${root}/telemetry-aware-scheduling/deploy/"

--- a/telemetry-aware-scheduling/README.md
+++ b/telemetry-aware-scheduling/README.md
@@ -93,11 +93,14 @@ A secret can be created with:
 ``
 kubectl create secret tls extender-secret --cert /etc/kubernetes/<PATH_TO_CERT> --key /etc/kubernetes/<PATH_TO_KEY> 
 ``
-In order to build and deploy run:
+In order to deploy run:
 
-``make build && make image && kubectl apply -f deploy/``
+``kubectl apply -f deploy/``
 
 After this is run TAS should be operable in the cluster and should be visible after running ``kubectl get pods``
+
+Note: If you want to create the build and the image you can still do it by running ``make build && make image`` 
+This will build locally the image ``tasextender``. Once created you may replace it into the deployment [file](https://github.com/intel/platform-aware-scheduling/blob/master/telemetry-aware-scheduling/deploy/tas-deployment.yaml#L28).
 
 #### Descheduling workloads
 Where there is a descheduling strategy in a policy, TAS will label nodes as violators if they break any of the associated rules. In order to deschedule these workloads the [Kubernetes Descheduler](https://github.com/kubernetes-sigs/descheduler) should be used.

--- a/telemetry-aware-scheduling/deploy/tas-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --key=/tas/cert/tls.key
         - --cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - --v=2
-        image: tasextender
+        image: intel/telemetry-aware-scheduling
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:


### PR DESCRIPTION
Changes are implemented to allow TAS deployment by pulling its recently
available image at the Intel registry. The changes are related to the image
location in the deployment and its documentation. Also, we made changes
in the CI to keep the e2e tests running with a locally built image and with
kind v0.11.1 to align with k8s 1.22