### PR TITLE
Fix handling of nil dontschedule strategy

### DIFF
--- a/.github/e2e/e2e_test.go
+++ b/.github/e2e/e2e_test.go
@@ -307,15 +307,6 @@ func getTASPolicy(name string, str string, metric string, operator string, targe
 			},
 		},
 	}
-	if str != dontschedule.StrategyType {
-		pol.Spec.Strategies[dontschedule.StrategyType] =
-			api.TASPolicyStrategy{
-				PolicyName: "filter1",
-				Rules: []api.TASPolicyRule{
-					{Metricname: "filter1_metric", Operator: "Equals", Target: 2000000},
-				},
-			}
-	}
 	return pol
 }
 

--- a/telemetry-aware-scheduling/pkg/telemetryscheduler/telemetryscheduler.go
+++ b/telemetry-aware-scheduling/pkg/telemetryscheduler/telemetryscheduler.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
 	"github.com/intel/platform-aware-scheduling/extender"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/cache"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/metrics"
@@ -15,8 +18,6 @@ import (
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/dontschedule"
 	"github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/strategies/scheduleonmetric"
 	telemetrypolicy "github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 )
 
 var tasPolicy = "telemetry-policy"
@@ -193,8 +194,10 @@ func (m MetricsExtender) filterNodes(args extender.Args) *extender.FilterResult 
 	}
 	dontscheduleStrategy, err := m.getDontScheduleStrategy(policy)
 	if err != nil {
-		klog.V(2).InfoS("Don't scheduler strategy failed "+err.Error(), "component", "extender")
-		return nil
+		klog.V(4).InfoS("Returning all nodes "+err.Error(), "component", "extender")
+		return &extender.FilterResult{
+			Nodes: args.Nodes,
+		}
 	}
 	violatingNodes := dontscheduleStrategy.Violated(m.cache)
 	if len(args.Nodes.Items) == 0 {


### PR DESCRIPTION
Correct handling when the dontschedule strategy is not defined
This makes an undefined dontschedule strategy in a policy
result in no filtering to the node list.

Signed-off-by: killianmuldoon <kmuldoon@vmware.com>