### PR TITLE
Multimetric rules operator

### DIFF
--- a/telemetry-aware-scheduling/README.md
+++ b/telemetry-aware-scheduling/README.md
@@ -183,8 +183,42 @@ There can be four strategy types in a policy file and rules associated with each
      If neither metric would be greater than 100, no label would be created. When there are multiple candidates with equal values, the resulting label is
      random among the equal candidates. Label cleanup happens automatically. An example of the labeling strategy can be found in [here](docs/strategy-labeling-example.md)
 
-dontschedule and deschedule - which incorporate multiple rules - function with an OR operator. That is if any single rule is broken the strategy is considered violated.
-Telemetry policies are namespaced, meaning that under normal circumstances a workload can only be associated with a pod in the same namespaces.
+Telemetry policies are namespaced, meaning that under normal circumstances a workload can only be associated with a pod in the same namespaces.   
+dontschedule and deschedule strategies - which incorporate multiple rules - works with an OR operator (default value). That is if any single rule is broken the strategy is considered violated.
+For the user-cases that request the use of other operators, the policy allows more descriptive operators such as `anyOf` and `allOf` which are equivalent to OR and AND operators, respectively. For example:
+
+````
+apiVersion: telemetry.intel.com/v1alpha1
+kind: TASPolicy
+metadata:
+  name: multirules-policy
+  namespace: default
+spec:
+  strategies:
+    deschedule:
+      logicalOperator: allOf
+      rules:
+      - metricname: temperature
+        operator: GreaterThan
+        target: 80
+      - metricname: freeRAM
+        operator: LessThan
+        target: 200  
+    dontschedule:
+      logicalOperator: anyOf
+      rules:
+      - metricname: temperature
+        operator: GreaterThan
+        target: 80
+      - metricname: freeRAM
+        operator: LessThan
+        target: 200  
+    scheduleonmetric:
+      rules:
+      - metricname: freeRAM
+        operator: LessThan
+````
+The deschedule strategy rule will be violated only if both metric rules are violated, while for dontschedule the violation will occur if one of the rules are broken. Note that the key:value map for the logicalOperator `anyOf` can be omitted, i.e., it has the same effect of the previous policy example (OR as default operator).  
 
 ### Configuration flags
 The below flags can be passed to the binary at run time.

--- a/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
@@ -35,13 +35,18 @@ spec:
                    properties:
                      policyName:
                        type: string
+                     logicalOperator:
+                       type: string
+                       enum: ["allOf", "anyOf"]
                      rules:
                        items:
+                         description: Set rules parameters per strategy
                          properties:
                            metricname:
                              type: string
                            operator:
                              type: string
+                             enum: ["Equals","LessThan","GreaterThan"]
                            target:
                              format: int64
                              type: integer

--- a/telemetry-aware-scheduling/pkg/strategies/deschedule/strategy_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/deschedule/strategy_test.go
@@ -100,9 +100,194 @@ func TestDescheduleStrategy_Violated(t *testing.T) {
 		args args
 		want map[string]interface{}
 	}{
-		{name: "One node violating", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 9}}}, args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{"node-1": nil}},
-		{name: "No nodes violating", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 11}}}, args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
-		{name: "No metric found", d: &Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "mem", Operator: "GreaterThan", Target: 9}}}, args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "One node violating",
+			d:    strategyRuleDefault("test name", "memory", "GreaterThan", 9),
+			args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating",
+			d:    strategyRuleDefault("test name", "memory", "GreaterThan", 11),
+			args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "No metric found",
+			d:    strategyRuleDefault("test name", "mem", "GreaterThan", 9),
+			args: args{cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "One node violating w/ a blank logical operator",
+			d:    strategyRule("test-logic-1", "", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating w/ anyOf",
+			d:    strategyRule("test-logic-2", "anyOf", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating w/ allOf",
+			d:    strategyRule("test-logic-3", "allOf", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "no metric w/ blank logic operator",
+			d:    strategyRule("test-logic-4", "", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "no metric w/ anyOf",
+			d:    strategyRule("test-logic-5", "anyOf", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "no metric w/ allOf",
+			d:    strategyRule("test-logic-6", "allOf", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the 1st rule w/o logical operator",
+			d: &Strategy{PolicyName: "test-logic-7",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 2nd rule w/o logical operator",
+			d: &Strategy{PolicyName: "test-logic-8",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and 2nd rules w/o logical operator",
+			d: &Strategy{PolicyName: "test-logic-9",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/o logical operator",
+			d: &Strategy{PolicyName: "test-logic-10",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No node violating without logical operator",
+			d: &Strategy{PolicyName: "test-logic-11",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule w/ blank logical operator",
+			d: &Strategy{PolicyName: "test-logic-12",
+				LogicalOperator: "",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the second rule w/ blank logical operator",
+			d: &Strategy{PolicyName: "test-logic-13",
+				LogicalOperator: "",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1s and 2nd rules w/ blank logical operator",
+			d: &Strategy{PolicyName: "test-logic-14",
+				LogicalOperator: "",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ blank logical operator",
+			d: &Strategy{PolicyName: "test-logic-15",
+				LogicalOperator: "",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating w/ blank logical operator",
+			d: &Strategy{PolicyName: "test-logic-16",
+				LogicalOperator: "",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule with anyOf",
+			d: &Strategy{PolicyName: "test-logic-17",
+				LogicalOperator: "anyOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the second rule with anyOf",
+			d: &Strategy{PolicyName: "test-logic-18",
+				LogicalOperator: "anyOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1s and 2nd rules with anyOf",
+			d: &Strategy{PolicyName: "test-logic-19",
+				LogicalOperator: "anyOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ anyOf",
+			d: &Strategy{PolicyName: "test-logic-20",
+				LogicalOperator: "anyOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating with anyOf",
+			d: &Strategy{PolicyName: "test-logic-21",
+				LogicalOperator: "anyOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule with allOf",
+			d: &Strategy{PolicyName: "test-logic-22",
+				LogicalOperator: "allOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the second rule with allOf",
+			d: &Strategy{PolicyName: "test-logic-23",
+				LogicalOperator: "allOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the 1s and 2nd rules with allOf",
+			d: &Strategy{PolicyName: "test-logic-24",
+				LogicalOperator: "allOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ anyOf",
+			d: &Strategy{PolicyName: "test-logic-25",
+				LogicalOperator: "allOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 9),
+					metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "No nodes violating with allOf",
+			d: &Strategy{PolicyName: "test-logic-26",
+				LogicalOperator: "allOf",
+				Rules: []v1.TASPolicyRule{
+					metricRules("memory", "GreaterThan", 90),
+					metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -111,6 +296,11 @@ func TestDescheduleStrategy_Violated(t *testing.T) {
 			if err != nil {
 				klog.InfoS("testing metric write on cache failed"+err.Error(), "component", "testing")
 			}
+			err = tt.args.cache.WriteMetric("cpu", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+				Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+			if err != nil {
+				t.Errorf("Cannot write metric to mock cach for test: %v", err)
+			}
 			if got := tt.d.Violated(tt.args.cache); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Strategy.Violated() = %v, want %v", got, tt.want)
 			}
@@ -118,6 +308,27 @@ func TestDescheduleStrategy_Violated(t *testing.T) {
 	}
 }
 
+func strategyRuleDefault(policyname, metricname, operator string, target int64) *Strategy {
+	return &Strategy{
+		PolicyName: policyname,
+		Rules: []v1.TASPolicyRule{
+			metricRules(metricname, operator, target)}}
+}
+func strategyRule(policyname, logicalOp, metricname, operator string, target int64) *Strategy {
+	return &Strategy{
+		PolicyName:      policyname,
+		LogicalOperator: logicalOp,
+		Rules: []v1.TASPolicyRule{
+			metricRules(metricname, operator, target)}}
+}
+
+func metricRules(metricname string, operator string, target int64) v1.TASPolicyRule {
+	return v1.TASPolicyRule{
+		Metricname: metricname,
+		Operator:   operator,
+		Target:     target,
+	}
+}
 func TestDescheduleStrategy_StrategyType(t *testing.T) {
 	tests := []struct {
 		name string

--- a/telemetry-aware-scheduling/pkg/strategies/dontschedule/strategy_test.go
+++ b/telemetry-aware-scheduling/pkg/strategies/dontschedule/strategy_test.go
@@ -24,22 +24,199 @@ func TestDontScheduleStrategy_Violated(t *testing.T) {
 		args args
 		want map[string]interface{}
 	}{
-		{name: "One node violating", d: Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 9}}}, args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{"node-1": nil}},
-		{name: "No nodes violating", d: Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "memory", Operator: "GreaterThan", Target: 11}}}, args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
-		{name: "No metric found", d: Strategy{PolicyName: "test name", Rules: []v1.TASPolicyRule{{Metricname: "mem", Operator: "GreaterThan", Target: 9}}}, args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "One node violating",
+			d:    strategyRuleDefault("test name", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating",
+			d:    strategyRuleDefault("test name", "memory", "GreaterThan", 11),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "No metric found",
+			d:    strategyRuleDefault("test name", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{}},
+		{name: "One node violating w/ a blank logical operator",
+			d:    strategyRule("test-logic-1", "", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()}, want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating w/ anyOf",
+			d:    strategyRule("test-logic-2", "anyOf", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating w/ allOf",
+			d:    strategyRule("test-logic-3", "allOf", "memory", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "no metric w/ blank logic operator",
+			d:    strategyRule("test-logic-4", "", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "no metric w/ anyOf",
+			d:    strategyRule("test-logic-5", "anyOf", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "no metric w/ allOf",
+			d:    strategyRule("test-logic-6", "allOf", "mem", "GreaterThan", 9),
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the 1st rule w/o logical operator",
+			d: Strategy{PolicyName: "test-logic-7", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 2nd rule w/o logical operator",
+			d: Strategy{PolicyName: "test-logic-8", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and 2nd rules w/o logical operator",
+			d: Strategy{PolicyName: "test-logic-9", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/o logical operator",
+			d: Strategy{PolicyName: "test-logic-10", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No node violating without logical operator",
+			d: Strategy{PolicyName: "test-logic-11", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule w/ blank logical operator",
+			d: Strategy{PolicyName: "test-logic-12", LogicalOperator: "", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the second rule w/ blank logical operator",
+			d: Strategy{PolicyName: "test-logic-13", LogicalOperator: "", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1s and 2nd rules w/ blank logical operator",
+			d: Strategy{PolicyName: "test-logic-14", LogicalOperator: "", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ blank logical operator",
+			d: Strategy{PolicyName: "test-logic-15", LogicalOperator: "", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating w/ blank logical operator",
+			d: Strategy{PolicyName: "test-logic-16", LogicalOperator: "", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule with anyOf",
+			d: Strategy{PolicyName: "test-logic-17", LogicalOperator: "anyOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the second rule with anyOf",
+			d: Strategy{PolicyName: "test-logic-18", LogicalOperator: "anyOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1s and 2nd rules with anyOf",
+			d: Strategy{PolicyName: "test-logic-19", LogicalOperator: "anyOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ anyOf",
+			d: Strategy{PolicyName: "test-logic-20", LogicalOperator: "anyOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "No nodes violating with anyOf",
+			d: Strategy{PolicyName: "test-logic-21", LogicalOperator: "anyOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the first rule with allOf",
+			d: Strategy{PolicyName: "test-logic-22", LogicalOperator: "allOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the second rule with allOf",
+			d: Strategy{PolicyName: "test-logic-23", LogicalOperator: "allOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "One node violating the 1s and 2nd rules with allOf",
+			d: Strategy{PolicyName: "test-logic-24", LogicalOperator: "allOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{"node-1": nil}},
+		{name: "One node violating the 1st and no metric found for 2nd w/ anyOf",
+			d: Strategy{PolicyName: "test-logic-25", LogicalOperator: "allOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 9),
+				metricRules("cpu-x", "GreaterThan", 90)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
+		{name: "No nodes violating with allOf",
+			d: Strategy{PolicyName: "test-logic-26", LogicalOperator: "allOf", Rules: []v1.TASPolicyRule{
+				metricRules("memory", "GreaterThan", 90),
+				metricRules("cpu", "GreaterThan", 900)}},
+			args: args{cache: cache.MockEmptySelfUpdatingCache()},
+			want: map[string]interface{}{}},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1, Value: *resource.NewQuantity(10, resource.DecimalSI)}})
+			err := tt.args.cache.WriteMetric("memory", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+				Value: *resource.NewQuantity(10, resource.DecimalSI)}})
 			if err != nil {
 				klog.V(4).InfoS(err.Error(), "component", "testing")
 				klog.Exit(err)
+			}
+			err = tt.args.cache.WriteMetric("cpu", metrics.NodeMetricsInfo{"node-1": {Timestamp: time.Now(), Window: 1,
+				Value: *resource.NewQuantity(200, resource.DecimalSI)}})
+			if err != nil {
+				t.Errorf("Cannot write metric to mock cach for test: %v", err)
 			}
 			if got := tt.d.Violated(tt.args.cache); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Strategy.Violated() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func strategyRuleDefault(policyname, metricname, operator string, target int64) Strategy {
+	return Strategy{
+		PolicyName: policyname,
+		Rules: []v1.TASPolicyRule{
+			metricRules(metricname, operator, target)}}
+}
+func strategyRule(policyname, logicalOp, metricname, operator string, target int64) Strategy {
+	return Strategy{
+		PolicyName:      policyname,
+		LogicalOperator: logicalOp,
+		Rules: []v1.TASPolicyRule{
+			metricRules(metricname, operator, target)}}
+}
+
+func metricRules(metricname string, operator string, target int64) v1.TASPolicyRule {
+	return v1.TASPolicyRule{
+		Metricname: metricname,
+		Operator:   operator,
+		Target:     target,
 	}
 }
 

--- a/telemetry-aware-scheduling/pkg/strategies/labeling/strategy.go
+++ b/telemetry-aware-scheduling/pkg/strategies/labeling/strategy.go
@@ -78,6 +78,18 @@ func (d *Strategy) Violated(cache cache.Reader) map[string]interface{} {
 		}
 	}
 
+	if d.LogicalOperator == "allOf" {
+		for nodeName := range violatingNodes {
+			if _, ok := violatingNodes[nodeName]; ok {
+				if res, ok := violatingNodes[nodeName].(*violationResultType); ok {
+					if len(res.ruleResults) != len(d.Rules) {
+						delete(violatingNodes, nodeName)
+					}
+				}
+			}
+		}
+	}
+
 	return violatingNodes
 }
 

--- a/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1/types.go
+++ b/telemetry-aware-scheduling/pkg/telemetrypolicy/api/v1alpha1/types.go
@@ -23,8 +23,9 @@ type TASPolicy struct {
 
 // TASPolicyStrategy contains a set of TASPolicyRule which define the strategy.
 type TASPolicyStrategy struct {
-	PolicyName string          `json:"policyName"`
-	Rules      []TASPolicyRule `json:"rules"`
+	PolicyName      string          `json:"policyName"`
+	LogicalOperator string          `json:"logicalOperator,omitempty"`
+	Rules           []TASPolicyRule `json:"rules"`
 }
 
 // TASPolicyRule contains the parameters for the strategy rule.


### PR DESCRIPTION
TAS can operate with OR logic ( "anyOf" ) in multi rules within the same strategy.  This PR has the modifications to allow the effect of AND logic ( "allOf" ) for multi rules strategies.  The changes do not affect the previous behavior, i.e., old policies (without the new operator) are still applicable.