### PR TITLE
Use golang 1.17 builder image for gas

### DIFF
--- a/gpu-aware-scheduling/deploy/images/Dockerfile_gpu-extender
+++ b/gpu-aware-scheduling/deploy/images/Dockerfile_gpu-extender
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.17.7-alpine as builder
+FROM golang:1.17-alpine as builder
 COPY . /src_root
 WORKDIR /src_root/gpu-aware-scheduling
 RUN mkdir -p /install_root/etc && adduser -D -u 10001 gas && tail -1 /etc/passwd > /install_root/etc/passwd \


### PR DESCRIPTION
This drops the last digit from the builder image. This way end users
who do build will get the latest security version of the golang base
libs.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>