### PR TITLE
Fix for kustomization fails with version >= 3.0.0 because namespace

### DIFF
--- a/gpu-aware-scheduling/docs/nfd/kustom/env_vars.yaml
+++ b/gpu-aware-scheduling/docs/nfd/kustom/env_vars.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nfd-worker
+  namespace: node-feature-discovery
 spec:
   template:
     spec:

--- a/gpu-aware-scheduling/docs/nfd/kustom/external_resources.yaml
+++ b/gpu-aware-scheduling/docs/nfd/kustom/external_resources.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nfd-master
+  namespace: node-feature-discovery
 spec:
   template:
     spec:


### PR DESCRIPTION
This fix is related to unable to deploy nfd with kustomization due to overlays not specifying a namespace

Signed-off-by: Liu, Rachel A <rachel.a.liu@intel.com>