### PR TITLE
Redirect the endpoint for the cni install

### DIFF
--- a/.github/scripts/e2e_setup_cluster.sh
+++ b/.github/scripts/e2e_setup_cluster.sh
@@ -10,7 +10,7 @@ APP_NAME="tasextender"
 APP_DOCKER_TAG="${APP_NAME}:latest"
 K8_ADDITIONS_PATH="${root}/.github/scripts/policies"
 TMP_DIR="${root}/tmp"
-CNIS_DAEMONSET_URL="https://raw.githubusercontent.com/intel/multus-cni/master/e2e/cni-install.yml"
+CNIS_DAEMONSET_URL="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v3.9.1/e2e/cni-install.yml"
 CNIS_NAME="cni-plugins"
 # running the latest available image my default, unless instructed to
 KIND_IMAGE="kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e"


### PR DESCRIPTION
Update the path for the cni install file due to recent changes in the multus-cni repo