### PR TITLE
Address static-analysis worfkflow issues and linting

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -40,12 +40,12 @@ jobs:
     name: Shellcheck
     runs-on: ${{ inputs.runsOn }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          scandir: ${{ inputs.scanDir }}
-          ignore_paths: ${{ inputs.ignoreDir }}
+      - uses: actions/checkout@v3
+      - run: |
+          wget -q https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
+          tar -xvf shellcheck-stable.linux.x86_64.tar.xz
+          shellcheck-stable/shellcheck -V; find . -name '*.sh' -print -exec sha256sum {} \;; find . -type f \( -name "*.sh" \) -print -exec shellcheck-stable/shellcheck -a -s bash -S warning -f gcc {} \;;
+        shell: bash
 
   hadolint:
     name: Hadolint
@@ -90,11 +90,5 @@ jobs:
         with:
           go-version: ${{ inputs.goVersion  }}
       - name: Running golang CI for ${{matrix.workingdir}}
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: ${{ inputs.goLangCIVersion  }}
-          skip-go-installation: true
-          working-directory: ${{matrix.workingdir }}
-          # Additional linting tools can be added here
-          args: --timeout=5m -v --color='always'
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@${{ inputs.goLangCIVersion }} && cd ./${{ matrix.workingdir }} && golangci-lint run --timeout=5m -v --color='always' && cd ..
 

--- a/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache.go
+++ b/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache.go
@@ -43,7 +43,7 @@ const (
 	expectedGpuSplitCount    = 2
 )
 
-//nolint: gochecknoglobals // only mocked APIs are allowed as globals
+//nolint:gochecknoglobals // only mocked APIs are allowed as globals
 var (
 	internCacheAPI InternalCacheAPI
 )
@@ -55,7 +55,7 @@ var (
 	errBadArgs       = errors.New("bad args")
 )
 
-//nolint: gochecknoinits // only mocked APIs are allowed in here
+//nolint:gochecknoinits // only mocked APIs are allowed in here
 func init() {
 	internCacheAPI = &internalCacheAPI{}
 }

--- a/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache_test.go
+++ b/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache_test.go
@@ -49,7 +49,7 @@ func TestNewCache(t *testing.T) {
 	})
 }
 
-//nolint: gochecknoglobals // only test resource
+//nolint:gochecknoglobals // only test resource
 var dummyCache *Cache
 
 func (c *Cache) reset() {

--- a/gpu-aware-scheduling/pkg/gpuscheduler/scheduler.go
+++ b/gpu-aware-scheduling/pkg/gpuscheduler/scheduler.go
@@ -53,7 +53,7 @@ const (
 	base10                  = 10
 )
 
-// nolint: gochecknoglobals // only mocked APIs are allowed as globals
+//nolint:gochecknoglobals // only mocked APIs are allowed as globals
 var (
 	iCache CacheAPI
 )
@@ -70,7 +70,7 @@ var (
 	errResConflict = errors.New("resources conflict")
 )
 
-// nolint: gochecknoinits // only mocked APIs are allowed in here
+//nolint:gochecknoinits // only mocked APIs are allowed in here
 func init() {
 	iCache = &cacheAPI{}
 }

--- a/gpu-aware-scheduling/pkg/gpuscheduler/scheduler_test.go
+++ b/gpu-aware-scheduling/pkg/gpuscheduler/scheduler_test.go
@@ -36,7 +36,7 @@ func getDummyExtender(objects ...runtime.Object) *GASExtender {
 	return NewGASExtender(clientset, true, true, "")
 }
 
-//nolint: gochecknoglobals // only test resource
+//nolint:gochecknoglobals // only test resource
 var emptyExtender *GASExtender
 
 func getEmptyExtender() *GASExtender {


### PR DESCRIPTION
This PR will:
- update Shellcheck and GolangCI-lint commands to use a new version of Shellcheck
- address linting issues found in GAS
- temporarily remove the GAS module from the golangci lint scans