### PR TITLE
Improve container security

### DIFF
--- a/.github/scripts/e2e_setup_cluster.sh
+++ b/.github/scripts/e2e_setup_cluster.sh
@@ -247,7 +247,7 @@ docker cp kind-control-plane:/etc/kubernetes/pki/ca.key "${mount_dir}/certs/clie
 
 
 kubectl create secret tls extender-secret --cert "${mount_dir}/certs/client.crt" --key "${mount_dir}/certs/client.key"
-sed "s/intel\/telemetry-aware-scheduling/tasextender/g" "${root}/telemetry-aware-scheduling/deploy/tas-deployment.yaml" -i
+sed "s/intel\/telemetry-aware-scheduling.*$/tasextender/g" "${root}/telemetry-aware-scheduling/deploy/tas-deployment.yaml" -i
 set_node_affinity_expression_label_key
 if [ "$CONTROL_PLANE_NODE_AFINITY_LABEL" != "$NODE_AFFINITY_LABEL_KEY"  ]; then
   sed "s/control-plane/$NODE_AFFINITY_LABEL_KEY/g" "$TAS_DEPLOYMENT_FILE" -i

--- a/telemetry-aware-scheduling/deploy/charts/prometheus_custom_metrics_helm_chart/templates/custom-metrics-apiserver-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/charts/prometheus_custom_metrics_helm_chart/templates/custom-metrics-apiserver-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
-        image: directxman12/k8s-prometheus-adapter-amd64
+        image: directxman12/k8s-prometheus-adapter-amd64:v0.8.4
         args:
         - --secure-port=6443
         - --tls-cert-file=/var/run/serving-cert/tls.crt
@@ -29,6 +29,16 @@ spec:
         - --metrics-relist-interval=1m
         - --v=10
         - --config=/etc/adapter/config.yaml
+        securityContext:
+          capabilities:
+            drop: [ 'ALL' ]
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 6443
         volumeMounts:
@@ -40,6 +50,13 @@ spec:
           readOnly: true
         - mountPath: /tmp
           name: tmp-vol
+        resources:
+          limits:
+            memory: "500Mi"
+            cpu: "500m"
+          requests:
+            memory: "150Mi"
+            cpu: "300m"
       volumes:
       - name: volume-serving-cert
         secret:

--- a/telemetry-aware-scheduling/deploy/health-metric-demo/demo-pod.yaml
+++ b/telemetry-aware-scheduling/deploy/health-metric-demo/demo-pod.yaml
@@ -19,6 +19,10 @@ spec:
       - name: nginx
         image: nginx:latest
         imagePullPolicy: IfNotPresent
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
         resources:
           limits:
             telemetry/scheduling: 1

--- a/telemetry-aware-scheduling/deploy/tas-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-deployment.yaml
@@ -29,11 +29,14 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
-            drop:
-              - all
+            drop: [ 'ALL' ]
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 10001
+          allowPrivilegeEscalation: false
+          runAsGroup: 10001
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: certs
           mountPath: /tas/cert

--- a/telemetry-aware-scheduling/deploy/tas-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --key=/tas/cert/tls.key
         - --cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - --v=2
-        image: intel/telemetry-aware-scheduling
+        image: intel/telemetry-aware-scheduling:0.3.0
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:


### PR DESCRIPTION
This PR will:
- tighten custom-metrics-apiserver container security
- improve health metric demo container security
- improve TAS container security
- specify telemetry-aware-scheduling image version for TAS POD deployment