### PR TITLE
Adding scheduled and manually run regression test workflows

### DIFF
--- a/.github/workflows/end-to-end-test.yaml
+++ b/.github/workflows/end-to-end-test.yaml
@@ -27,6 +27,9 @@ on:
         required: false
         type: string
         default: 'false'
+      codeBranch:
+        required: false
+        type: string
 
 jobs:
   docker-image-cleanup:
@@ -35,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.codeBranch  }}
       - name: Show available space
         run: df -h
       - name: Remove docker dangling images
@@ -48,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.codeBranch }}
       - name: Set up Go version
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/regression-workflow.yaml
+++ b/.github/workflows/regression-workflow.yaml
@@ -1,0 +1,110 @@
+name: Regression Tests
+
+on:
+  schedule:
+    # At 07:08 PM, on day 1 and 15 of the month
+    - cron: '08 19 1,15 * *'
+  workflow_dispatch:
+    inputs:
+      codeBranch:
+        description: 'Branch of the TAS repo that you want to run the workflow against'
+        required: true
+        default: 'master'
+
+
+jobs:
+  private-repo-break-condition:
+    name: 'Repo '
+    runs-on: 'self-hosted'
+    if: ( !contains(github.repository, '/platform-aware-scheduling') )
+    steps:
+      - name: Simple acknowledgement
+        run: echo "Starting regression tests..."
+  current_branch:
+    runs-on: self-hosted
+    needs: [private-repo-break-condition]
+    outputs:
+      extract_branch: ${{ steps.extract_branch.outputs.branch }}
+    steps:
+      - name: current branch
+        id: extract_branch
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            echo "::set-output name=BRANCH::$(echo ${GITHUB_REF#refs/heads/})"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "::set-output name=BRANCH::${{ inputs.codeBranch  }}"
+          else
+            echo "::set-output name=BRANCH::INVALID_EVENT_BRANCH_UNKNOWN"
+          fi
+
+  end-to-end-test-local-K8s-v19:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ current_branch  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: true
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7"
+
+
+  end-to-end-test-local-K8s-v20:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v19  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
+
+  end-to-end-test-local-K8s-v21:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v20  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1"
+
+  end-to-end-test-local-K8s-v22:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v21  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41"
+
+  end-to-end-test-local-K8s-v23:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v22 ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61"
+
+  end-to-end-test-local-K8s-v24:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v23  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
+
+  end-to-end-test-local-K8s-v25:
+    uses: ./.github/workflows/end-to-end-test.yaml
+    needs: [ end-to-end-test-local-K8s-v24  ]
+    with:
+      runson: self-hosted-kind
+      cleanup: false
+      isLocal: "true"
+      codeBranch: ${{ needs.current_branch.outputs.extract_branch }}
+      imageHash: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+


### PR DESCRIPTION
This workflow will run our Kind based E2E tests across v19-v25 of K8. The regression worfklow will can be triggered manually and will also have a scheduled run (at 7:18 PM, on the 1st, 15th day of the month)

The WF will not run in the repo for now: https://github.com/madalazar/platform-aware-scheduling/actions/runs/3818328716/jobs/6495162711. It will be enabled in a later PR

Signed-off-by: Madalina Lazar <madalina.lazar@intel.com>
