### PR TITLE
Using TAS image 0.4.0 when deploying 

### DIFF
--- a/telemetry-aware-scheduling/deploy/tas-deployment.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - --key=/tas/cert/tls.key
         - --cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - --v=2
-        image: intel/telemetry-aware-scheduling:0.3.0
+        image: intel/telemetry-aware-scheduling:0.4.0
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:


### PR DESCRIPTION
When deploying TAS, the image that is used from DockerHub is now versioned. Instead of `:latest` we will use the latest release version, now: `0.4.0`