### PR TITLE
informer interval fix

### DIFF
--- a/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache.go
+++ b/gpu-aware-scheduling/pkg/gpuscheduler/node_resource_cache.go
@@ -38,7 +38,7 @@ const (
 	add                      = true
 	remove                   = false
 	workerWaitTime           = time.Millisecond * 100
-	informerInterval         = time.Second * 30
+	informerInterval         = 0
 	gpuDescheduleLabelPrefix = "gas-deschedule-pods-"
 	podDescheduleString      = "gpu.aware.scheduling~1deschedule-pod"
 	pciGroupValue            = "PCI_GROUP"


### PR DESCRIPTION
The informer refresh interval only adds to the apiserver load. Zero works fine, just like with TAS.