### PR TITLE
Update extender package versions for TAS, E2E

### DIFF
--- a/.github/e2e/go.mod
+++ b/.github/e2e/go.mod
@@ -3,7 +3,7 @@ module github.com/intel/platform-aware-scheduling/e2e
 go 1.19
 
 require (
-	github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling v0.4.0
+	github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling v0.5.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4

--- a/telemetry-aware-scheduling/go.mod
+++ b/telemetry-aware-scheduling/go.mod
@@ -3,7 +3,7 @@ module github.com/intel/platform-aware-scheduling/telemetry-aware-scheduling
 go 1.19
 
 require (
-	github.com/intel/platform-aware-scheduling/extender v0.4.0
+	github.com/intel/platform-aware-scheduling/extender v0.5.0
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4


### PR DESCRIPTION
* Bump extender version to v0.5.0 in TAS go.md
* Bump TAS module version to v0.5.0 in E2E go.mod
Signed-off-by: Madalina Lazar <madalina.lazar@intel.com>