### PR TITLE
Add BM ansible tests for internal repo

### DIFF
--- a/.github/workflows/BM-end-to-end.yaml
+++ b/.github/workflows/BM-end-to-end.yaml
@@ -1,0 +1,56 @@
+name: BM Ansible Script E2E Test
+
+on:
+  # This workflow would run at 1 AM every day
+  schedule:
+    - cron: '0 1 * * *'
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  CI_CNO_ANSIBLE_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler
+  CI_CNO_TAS_FOLDER: /usr/src/telemetry-scheduler
+  
+jobs:
+  exit-trigger:
+    if: ( !contains(github.repository, '/platform-aware-scheduling') )
+    uses: ./.github/workflows/bm-job-exit-trigger.yaml
+    with:
+      runson: self-hosted-ansible
+  pull-ci:
+    needs: [ exit-trigger ]
+    if: ${{ needs.exit-trigger.outputs.ansible-dir != '' || needs.exit-trigger.outputs.cno-ci-repo-name != ''  || needs.exit-trigger.outputs.cno-ci-branch-name != '' }}
+    uses: ./.github/workflows/checkout-cno-ci-repo-job.yaml
+    with:
+      runson: self-hosted-ansible
+      ci-cno-ansible-folder: /usr/src/ci_cno_ansible_telemetry_scheduler
+      ci-cno-repo-name: ${{ needs.exit-trigger.outputs.cno-ci-repo-name }}
+      ci-cno-branch-name: ${{ needs.exit-trigger.outputs.cno-ci-branch-name }}
+    secrets:
+      CNO_CI_TOKEN: ${{ secrets.PASSWORD_PAT_CNO_CI }}
+  pull-tas:
+    needs: [ pull-ci ]
+    uses: ./.github/workflows/checkout-tas-repo-job.yaml
+    with:
+      runson: self-hosted-ansible
+      ci-cno-tas-ansible-folder: /usr/src/telemetry-scheduler
+  runscripts:
+    name: Run ansible scripts for E2E
+    needs: [ pull-ci, pull-tas ]
+    runs-on: self-hosted-ansible
+    defaults:
+      run:
+        working-directory: ${{ env.CI_CNO_ANSIBLE_FOLDER }}
+    env:
+      CI_CNO_PLAYBOOK_COMMON_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler/playbooks/common
+      CI_CNO_PLAYBOOK_TAS_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler/playbooks/tas
+      ANSIBLE_TELEMETRY_FOLDER_DESTINATION_PARAM: "destination_dir=/usr/src/telemetry-scheduler"
+      ANSIBLE_TAS_FOLDER_DESTINATION_PARAM: "destination_dir=/usr/src/telemetry-scheduler/telemetry-aware-scheduling/"
+    steps:
+    - name: BM Build & test TAS
+      run: ansible-playbook -i ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_TAS_FOLDER }}/build.yml -e ${{ env.ANSIBLE_TAS_FOLDER_DESTINATION_PARAM }}
+    - name: BM Smoke Test
+      run: ansible-playbook -i  ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_TAS_FOLDER }}/smokeTest.yml -e ${{ env.ANSIBLE_TAS_FOLDER_DESTINATION_PARAM }}
+    - name: BM Clean-up
+      run: ansible-playbook -i  ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_COMMON_FOLDER }}/commonCleanup.yml -e ${{ env.ANSIBLE_TELEMETRY_FOLDER_DESTINATION_PARAM }} 
+

--- a/.github/workflows/BM-static-analysis.yaml
+++ b/.github/workflows/BM-static-analysis.yaml
@@ -1,0 +1,57 @@
+name: BM Ansible Script SCA Test
+
+on:
+  # This workflow would run at 1 AM every day
+  schedule:
+    - cron: '0 1 * * *'
+  push:
+    branches: [ '**' ]
+
+env:
+  CI_CNO_ANSIBLE_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler
+  CI_CNO_TAS_FOLDER: /usr/src/telemetry-scheduler-sca
+
+jobs:
+  exit-trigger:
+    if: ( !contains(github.repository, '/platform-aware-scheduling') )
+    uses: ./.github/workflows/bm-job-exit-trigger.yaml
+    with:
+      runson: self-hosted-ansible
+  pull-ci:
+    needs: [ exit-trigger ]
+    if: ${{ needs.exit-trigger.outputs.ansible-dir != '' &&  needs.exit-trigger.outputs.cno-ci-repo-name != '' &&  needs.exit-trigger.outputs.cno-ci-branch-name != '' }}
+    uses: ./.github/workflows/checkout-cno-ci-repo-job.yaml
+    with:
+      runson: self-hosted-ansible
+      ci-cno-repo-name: ${{ needs.exit-trigger.outputs.cno-ci-repo-name }}
+      ci-cno-branch-name: ${{ needs.exit-trigger.outputs.cno-ci-branch-name }}
+      ci-cno-ansible-folder: /usr/src/ci_cno_ansible_telemetry_scheduler 
+    secrets:
+      CNO_CI_TOKEN: ${{ secrets.PASSWORD_PAT_CNO_CI }}
+  pull-tas:
+    needs: [ pull-ci ]
+    uses: ./.github/workflows/checkout-tas-repo-job.yaml
+    with:
+      runson: self-hosted-ansible
+      ci-cno-tas-ansible-folder: /usr/src/telemetry-scheduler-sca
+  runscripts:
+    name: Run ansible scripts for SCA, Build & Test, mtls test
+    needs: [ pull-ci, pull-tas ]
+    runs-on: self-hosted-ansible
+    defaults:
+      run:
+        working-directory: ${{ env.CI_CNO_ANSIBLE_FOLDER }}
+    env:
+      CI_CNO_PLAYBOOK_COMMON_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler/playbooks/common
+      CI_CNO_PLAYBOOK_TAS_FOLDER: /usr/src/ci_cno_ansible_telemetry_scheduler/playbooks/tas
+      ANSIBLE_TELEMETRY_FOLDER_DESTINATION_PARAM: "destination_dir=/usr/src/telemetry-scheduler-sca"
+      ANSIBLE_TAS_FOLDER_DESTINATION_PARAM: "destination_dir=/usr/src/telemetry-scheduler-sca/telemetry-aware-scheduling/"
+    steps:
+      - name: BM Build & test TAS
+        run: ansible-playbook -i ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_TAS_FOLDER }}/build.yml -e ${{ env.ANSIBLE_TAS_FOLDER_DESTINATION_PARAM }}
+      - name: BM Static Analysis
+        run: ansible-playbook -i  ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_COMMON_FOLDER }}/commonTest.yml -e ${{ env.ANSIBLE_TELEMETRY_FOLDER_DESTINATION_PARAM }}
+      - name: BM mtlsTest
+        run: ansible-playbook -i  ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini /${{ env.CI_CNO_PLAYBOOK_TAS_FOLDER }}/mtlsTest.yml -e ${{ env.ANSIBLE_TAS_FOLDER_DESTINATION_PARAM }}
+      - name: BM Clean-up
+        run: ansible-playbook -i  ${{ env.CI_CNO_ANSIBLE_FOLDER }}/inventory_cni.ini ${{ env.CI_CNO_PLAYBOOK_COMMON_FOLDER }}/commonCleanup.yml -e ${{ env.ANSIBLE_TELEMETRY_FOLDER_DESTINATION_PARAM }}

--- a/.github/workflows/bm-job-exit-trigger.yaml
+++ b/.github/workflows/bm-job-exit-trigger.yaml
@@ -1,0 +1,54 @@
+name: BM exit trigger reusable job
+
+on:
+  workflow_call:
+    inputs:
+      runson:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+    outputs:
+      ansible-dir:
+        description: "Location of ansible"
+        value: ${{ jobs.exit-trigger.outputs.ansible-dir  }}
+      cno-ci-repo-name:
+        description: "CNO-CI repo name"
+        value: ${{ jobs.exit-trigger.outputs.cno-ci-repo-name  }}
+      cno-ci-branch-name:
+        description: "CNO-CI branch name"
+        value: ${{ jobs.exit-trigger.outputs.cno-ci-branch-name  }}
+
+
+jobs:
+  exit-trigger:
+    runs-on: ${{ inputs.runson }}
+    outputs:
+      ansible-dir: ${{steps.check-ansible.outputs.ansible-dir}}
+      cno-ci-repo-name: ${{steps.check-cno-ci-params.outputs.cno-ci-repo-name}}
+      cno-ci-branch-name: ${{steps.check-cno-ci-params.outputs.cno-ci-branch-name}}
+    steps:
+      - name: Check ansible is installed
+        id: check-ansible
+        run: |
+          ANSIBLE_DIR=$(which ansible)
+          if [[ -n "$ANSIBLE_DIR" ]]; then
+            echo $ANSIBLE_DIR
+            echo "::set-output name=ANSIBLE-DIR::$(echo $ANSIBLE_DIR)"            
+          fi
+      - name: Check CNO-CI repo name and branch
+        id: check-cno-ci-params
+        env:
+          CNO_CI_CONFIG_FOLDER: "../../cno-ci-config/ci_repo_parameters.cfg"
+        run: |
+          echo "$(pwd)"
+          CNO_CI_REPO=$(grep 'repo=' $CNO_CI_CONFIG_FOLDER  | cut -d '=' -f 2)
+          echo $CNO_CI_REPO
+          CNO_CI_BRANCH=$(grep 'branch=' $CNO_CI_CONFIG_FOLDER | cut -d '=' -f 2)
+          echo $CNO_CI_BRANCH
+          if [[ -n "$CNO_CI_REPO" ]]; then
+            echo "::set-output name=CNO-CI-REPO-NAME::$(echo $CNO_CI_REPO)"
+          fi
+          if [[ -n "$CNO_CI_BRANCH" ]]; then
+            echo "::set-output name=CNO-CI-BRANCH-NAME::$(echo $CNO_CI_BRANCH)"
+          fi
+

--- a/.github/workflows/checkout-cno-ci-repo-job.yaml
+++ b/.github/workflows/checkout-cno-ci-repo-job.yaml
@@ -1,0 +1,42 @@
+name: Pull repo branch that contains the required files for our BM tests
+
+on:
+  workflow_call:
+    inputs:
+      runson:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      ci-cno-ansible-folder:
+        required: true
+        type: string
+      ci-cno-repo-name:
+        required: true
+        type: string
+      ci-cno-branch-name:
+        required: true
+        type: string
+    secrets: 
+      CNO_CI_TOKEN:
+        required: true
+        description: 'Token required to access the CNO-CI repo'
+
+jobs:
+  pull-ci:
+    name: Pull ansible based scripts
+    runs-on: ${{ inputs.runson }}
+    env:
+      CI_CNO_INTERIM_PATH: ./cno-ci
+    steps:
+      - name: Clean-up Ansible script folder
+        run: rm -rvf ${{ inputs.ci-cno-ansible-folder }} && mkdir  ${{ inputs.ci-cno-ansible-folder  }}
+      - name: Checkout ansible script repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.ci-cno-repo-name }}
+          ref: ${{ inputs.ci-cno-branch-name }}
+          token: ${{ secrets.CNO_CI_TOKEN }}
+          path: ${{ env.CI_CNO_INTERIM_PATH }}
+      # This step is needed as the runner will move the content of its working  directory before pulling files from another repo
+      - name: Copy Ansible scripts folder to ${{ inputs.ci-cno-ansible-folder  }} and clean-up intermediary dir
+        run: mv ${{ env.CI_CNO_INTERIM_PATH }}/*  ${{ inputs.ci-cno-ansible-folder  }}  && rm -rf ${{ env.CI_CNO_INTERIM_PATH }}

--- a/.github/workflows/checkout-tas-repo-job.yaml
+++ b/.github/workflows/checkout-tas-repo-job.yaml
@@ -1,0 +1,41 @@
+name: Pull TAS code required for BM E2E tests
+
+on:
+  workflow_call:
+    inputs:
+      runson:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      ci-cno-tas-ansible-folder:
+        required: true
+        type: string
+
+jobs:
+  pull-tas:
+    name: Pull TAS code
+    runs-on: ${{ inputs.runson }}
+    steps:
+      # based on https://pwgen88.medium.com/getting-branch-name-in-github-actions-based-on-workflow-trigger-1d10b8515d37
+      - name: Fetch current repo branch for this run
+        id: extract_branch
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            echo "::set-output name=BRANCH::$(echo ${GITHUB_REF#refs/heads/})"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "::set-output name=BRANCH::$(echo ${GITHUB_HEAD_REF})"
+          elif [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            echo "::set-output name=BRANCH::$(echo ${GITHUB_REF#refs/heads/})"
+          else
+            echo "::set-output name=BRANCH::INVALID_EVENT_BRANCH_UNKNOWN"
+          fi
+      - name: Clean up TAS script folder
+        run: rm -rvf ${{ inputs.ci-cno-tas-ansible-folder }} && mkdir ${{ inputs.ci-cno-tas-ansible-folder  }}
+      - name: Check branch name
+        run: echo ${{ steps.extract_branch.outputs.branch }}
+      - name: Checkout PAS repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }} # repo branch to pickup the code to run on the tests
+      - name: Copy PAS repo to ${{ inputs.ci-cno-tas-ansible-folder   }}
+        run: cp -r ./*  ${{ inputs.ci-cno-tas-ansible-folder   }}


### PR DESCRIPTION
The workflows will not run on the public repo, they are set-up to be run only on the dev repo. 
These tests have the following behavior: 
- when code is pushed only SCA runs. 
- E2e tests will run when PR is created. With a PR open, every time we add a new commit to the PR both workflows will run. 
- the workflow also has a cron that will allow it to run once a day at 1:00 am.

