### PR TITLE
Update GAS extender library version

### DIFF
--- a/gpu-aware-scheduling/go.mod
+++ b/gpu-aware-scheduling/go.mod
@@ -3,7 +3,7 @@ module github.com/intel/platform-aware-scheduling/gpu-aware-scheduling
 go 1.19
 
 require (
-	github.com/intel/platform-aware-scheduling/extender v0.3.0
+	github.com/intel/platform-aware-scheduling/extender v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/stretchr/testify v1.8.1

--- a/gpu-aware-scheduling/go.sum
+++ b/gpu-aware-scheduling/go.sum
@@ -77,8 +77,8 @@ github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfre
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/intel/platform-aware-scheduling/extender v0.3.0 h1:NYQZm+JJlArGAPnZ0XW3J9dz7xWo0HtXhFloUuiZ0VA=
-github.com/intel/platform-aware-scheduling/extender v0.3.0/go.mod h1:faedj4GP7JLcPN+tu4eJrxpo7tY8ZoYwYTz5c0tbPsM=
+github.com/intel/platform-aware-scheduling/extender v0.5.0 h1:8uVRUpDJH1k3/dti99PdVe8oFjQ8P1zQsDxccT6qo4M=
+github.com/intel/platform-aware-scheduling/extender v0.5.0/go.mod h1:chYNDpdZ4P1veKCf5etN6nEYkgU1rWHRApViSHcxDxQ=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
Uses v0.5.0 now.