### PR TITLE
Security updates for health-metric demo

### DIFF
--- a/telemetry-aware-scheduling/.trivyignore
+++ b/telemetry-aware-scheduling/.trivyignore
@@ -1,0 +1,7 @@
+# This is to ignore tas-rbac-accounts.yaml:23-25, without the '*' TAS will not work
+# To limit the amount of metrics we expose, we have other guard rails that we put in place before TAS: 
+# - we limit what metrics are available in the Custom Metrics API to just node metrics 
+# - node metrics are filtered at ingestion as we only use proc and sys metrics from the Node Exporter
+# - if customers need more metrics, they have to manually update all these components to surface them
+AVD-KSV-0046
+

--- a/telemetry-aware-scheduling/deploy/charts/prometheus_node_exporter_helm_chart/templates/node-exporter-ds.yaml
+++ b/telemetry-aware-scheduling/deploy/charts/prometheus_node_exporter_helm_chart/templates/node-exporter-ds.yaml
@@ -20,8 +20,6 @@ spec:
       labels:
         k8s-app: {{ .Values.k8sAppName }}
         version: {{ .Values.version }}
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/telemetry-aware-scheduling/deploy/health-metric-demo/demo-pod.yaml
+++ b/telemetry-aware-scheduling/deploy/health-metric-demo/demo-pod.yaml
@@ -17,15 +17,46 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.23.3
         imagePullPolicy: IfNotPresent
         securityContext:
+          capabilities:
+            drop: [ 'ALL' ]
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false
+          runAsUser: 10001
+          runAsGroup: 10001
+        volumeMounts:
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: conf
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: tmp
+          mountPath: /tmp/nginx
         resources:
+          requests:
+            memory: "100Mi"
+            cpu: "50m"
           limits:
+            memory: "200Mi"
             telemetry/scheduling: 1
+            cpu: "100m"
+      volumes:
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      - name: conf
+        configMap:
+          name: nginx-conf
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/telemetry-aware-scheduling/deploy/health-metric-demo/nginx-config-map.yaml
+++ b/telemetry-aware-scheduling/deploy/health-metric-demo/nginx-config-map.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1 
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data: 
+  nginx.conf: |
+    worker_processes  auto;
+
+    error_log  /tmp/nginx/error.log warn;
+    pid        /tmp/nginx/nginx.pid;
+
+    events { 
+      worker_connections  1024; 
+    }
+
+    http { 
+      server {
+        listen 8090; # specify a port higher than 1024 if running as non-root user 
+        location / { 
+          add_header Content-Type text/plain;
+          return 200 'hello world';
+      } 
+     }
+    }


### PR DESCRIPTION
This PR will:
- use .trivyignore files to suppress ksv046 violations
- address an out-of-date annotation in the node-exporter pod: https://github.com/intel/platform-aware-scheduling/issues/114
- address some issues spotted by Trivy in the health-metric emo