### PR TITLE
Gas qps control

### DIFF
--- a/gpu-aware-scheduling/README.md
+++ b/gpu-aware-scheduling/README.md
@@ -99,6 +99,8 @@ name |type | description| usage | default|
 |enableAllowlist| bool | enable POD-annotation based GPU allowlist feature | --enableAllowlist| false
 |enableDenylist| bool | enable POD-annotation based GPU denylist feature | --enableDenylist| false
 |balancedResource| string | enable named resource balancing between GPUs | --balancedResource| ""
+|burst| int | burst value to use with kube client | --burst| 10
+|qps| int | qps value to use with kube client | --qps| 5
 
 Some features are based on the labels put onto pods, for full features list see [usage doc](docs/usage.md)
 

--- a/gpu-aware-scheduling/cmd/gas-scheduler-extender/main.go
+++ b/gpu-aware-scheduling/cmd/gas-scheduler-extender/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/intel/platform-aware-scheduling/extender"
@@ -22,13 +23,17 @@ var (
 )
 
 const (
-	l1 = klog.Level(1)
+	l1             = klog.Level(1)
+	defaultQPS     = 5
+	defaultBurst   = 10
+	maxQPSandBurst = 1000
 )
 
 func main() {
 	var (
 		kubeConfig, port, certFile, keyFile, caFile, balancedRes string
 		enableAllowlist, enableDenylist                          bool
+		burst, qps                                               uint
 	)
 
 	flag.StringVar(&kubeConfig, "kubeConfig", "/root/.kube/config", "location of kubernetes config file")
@@ -39,12 +44,22 @@ func main() {
 	flag.BoolVar(&enableAllowlist, "enableAllowlist", false, "enable allowed GPUs annotation (csv list of names)")
 	flag.BoolVar(&enableDenylist, "enableDenylist", false, "enable denied GPUs annotation (csv list of names)")
 	flag.StringVar(&balancedRes, "balancedResource", "", "enable resource balacing within a node")
+	flag.UintVar(&burst, "burst", defaultBurst, fmt.Sprintf("burst value used with kube client (limited to %d)", maxQPSandBurst))
+	flag.UintVar(&qps, "qps", defaultQPS, fmt.Sprintf("qps value used with kube client (limited to %d)", maxQPSandBurst))
 	klog.InitFlags(nil)
 	flag.Parse()
 
 	klog.V(l1).Infof("%s built on %s with go %s", version, buildDate, goVersion)
 
-	kubeClient, _, err := extender.GetKubeClient(kubeConfig)
+	for _, ptr := range []*uint{&qps, &burst} {
+		if *ptr > maxQPSandBurst {
+			klog.Warningf("Given flag value %d is too high. Limited to %d.", *ptr, maxQPSandBurst)
+			*ptr = maxQPSandBurst
+		}
+	}
+
+	kubeClient, _, err := extender.GetKubeClientExt(kubeConfig, int(burst), float32(qps))
+
 	if err != nil {
 		klog.Error("couldn't get kube client, cannot continue: ", err.Error())
 		os.Exit(1)

--- a/gpu-aware-scheduling/deploy/gas-deployment.yaml
+++ b/gpu-aware-scheduling/deploy/gas-deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - "--cert=/gas/cert/tls.crt"
         - "--key=/gas/cert/tls.key"
         - "--cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "--burst=100"
+        - "--qps=50"
         - "--v=4"
         image: intel/gpu-extender
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR adds command line args for defining the QPS and Burst values for the kubernetes client. The deployment takes this into use and increases the QPS and Burst values.