### PR TITLE
Small improvements to TAS and PAS repo

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,6 @@
+# Security Policy
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
+
+## Reporting a Vulnerability
+Please report any security vulnerabilities in this project [utilizing the guidelines here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).
+

--- a/telemetry-aware-scheduling/README.md
+++ b/telemetry-aware-scheduling/README.md
@@ -248,7 +248,7 @@ The below flags can be passed to the binary at run time.
 #### TAS Scheduler Extender
 name |type | description| usage | default|
 -----|------|-----|-------|-----|
-|kubeConfig| string |location of kubernetes configuration file | -kubeConfig /root/filename|~/.kube/config
+|kubeConfig| string |location of kubernetes configuration file | -kubeConfig $PATH_TO_KUBE_CONFIG/config|$HOME/.kube/config
 |syncPeriod|duration string| interval between refresh of telemetry data|-syncPeriod 1m| 1s
 |port| int | port number on which the scheduler extender will listen| -port 32000 | 9001
 |cert| string | location of the cert file for the TLS endpoint | --cert=/root/cert.txt| /etc/kubernetes/pki/ca.crt

--- a/telemetry-aware-scheduling/cmd/main.go
+++ b/telemetry-aware-scheduling/cmd/main.go
@@ -7,7 +7,10 @@ import (
 	"flag"
 	"os"
 
+	"k8s.io/client-go/util/homedir"
+
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -35,7 +38,7 @@ func main() {
 	var kubeConfig, port, certFile, keyFile, caFile, syncPeriod string
 
 	klog.InitFlags(nil)
-	flag.StringVar(&kubeConfig, "kubeConfig", "/root/.kube/config", "location of kubernetes config file")
+	flag.StringVar(&kubeConfig, "kubeConfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "location of kubernetes config file")
 	flag.StringVar(&port, "port", "9001", "port on which the scheduler extender will listen")
 	flag.StringVar(&certFile, "cert", "/etc/kubernetes/pki/ca.crt", "cert file extender will use for authentication")
 	flag.StringVar(&keyFile, "key", "/etc/kubernetes/pki/ca.key", "key file extender will use for authentication")


### PR DESCRIPTION
This PR will contain the following changes:
- Updating path to .kube/config to use $HOME in TAS entrypoint
- add security.md file to repo