### PR TITLE
Small follow-up validations implemented after fuzz tests

### DIFF
--- a/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
+++ b/telemetry-aware-scheduling/deploy/tas-policy-crd.yaml
@@ -44,6 +44,10 @@ spec:
                          properties:
                            metricname:
                              type: string
+                             # don't match if the following characters are not present
+                             # can't match \ or / as that is what TAS uses as keys in
+                             # the metric cache and \ is to breakdown Unicode characters 
+                             pattern: '^[a-zA-Z0-9_-]+$'
                            operator:
                              type: string
                              enum: ["Equals","LessThan","GreaterThan"]

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating.go
@@ -20,7 +20,10 @@ const (
 	l2                = 2
 )
 
-var errNull = errors.New("")
+var (
+	errNull              = errors.New("")
+	errInvalidMetricName = errors.New("invalid metric name")
+)
 
 // AutoUpdatingCache holds a map of metrics of interest with their associated NodeMetricsInfo object.
 type AutoUpdatingCache struct {
@@ -119,6 +122,12 @@ func (n *AutoUpdatingCache) WritePolicy(namespace string, policyName string, pol
 // It also increments a counter showing how many strategies are using the metric -
 // protecting it from deletion until there are no more associated strategies.
 func (n *AutoUpdatingCache) WriteMetric(metricName string, data metrics.NodeMetricsInfo) error {
+	if len(metricName) == 0 {
+		klog.V(l2).ErrorS(errInvalidMetricName, "Failed to write metric with metric name: "+metricName, "component", "controller")
+
+		return errInvalidMetricName
+	}
+
 	payload := nilPayloadCheck(data)
 	n.add(fmt.Sprintf(metricPath, metricName), payload)
 

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating.go
@@ -23,6 +23,7 @@ const (
 var (
 	errNull              = errors.New("")
 	errInvalidMetricName = errors.New("invalid metric name")
+	errInvalidPolicyName = errors.New("invalid policy name")
 )
 
 // AutoUpdatingCache holds a map of metrics of interest with their associated NodeMetricsInfo object.
@@ -113,6 +114,12 @@ func (n *AutoUpdatingCache) ReadPolicy(namespace string, policyName string) (tel
 
 // WritePolicy sends the passed object to be stored in the cache under the namespace/name.
 func (n *AutoUpdatingCache) WritePolicy(namespace string, policyName string, policy telemetrypolicy.TASPolicy) error {
+	if len(policyName) == 0 {
+		klog.V(l2).ErrorS(errInvalidPolicyName, "Failed to add policy with name: "+policyName, "component", "controller")
+
+		return errInvalidPolicyName
+	}
+
 	n.add(fmt.Sprintf(policyPath, namespace, policyName), policy)
 
 	return nil

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
@@ -201,6 +201,7 @@ func TestNodeMetricsCache_WriteMetric(t *testing.T) {
 		{"false name queried", MockEmptySelfUpdatingCache(), "memory_free", args{"memoryFREE"}, true},
 		{"number queried", MockEmptySelfUpdatingCache(), "1", args{"memoryFREE"}, true},
 		{"add existing metric", MockEmptySelfUpdatingCache(), "dummyMetric1", args{"dummyMetric1"}, false},
+		{"empty metric name", MockEmptySelfUpdatingCache(), "", args{""}, true},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
+++ b/telemetry-aware-scheduling/pkg/cache/autoupdating_test.go
@@ -124,11 +124,13 @@ func TestNodeMetricsCache_ReadPolicy(t *testing.T) {
 	}{
 		{"existing policy", MockSelfUpdatingCache(), args{mockPolicy}, mockPolicy, false},
 		{"non existing policy", MockSelfUpdatingCache(), args{mockPolicy}, mockPolicy2, true},
+		{"empty policy name", MockSelfUpdatingCache(), args{mockInvalidPolicyName1}, mockInvalidPolicyName1, true},
+		{"single character policy name", MockSelfUpdatingCache(), args{mockInvalidPolicyName2}, mockInvalidPolicyName2, false},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			err1 := tt.n.WritePolicy(tt.args.policy.Namespace, tt.args.policy.Name, mockPolicy)
+			err1 := tt.n.WritePolicy(tt.args.policy.Namespace, tt.args.policy.Name, tt.args.policy)
 			got, err2 := tt.n.ReadPolicy(tt.want.Namespace, tt.want.Name)
 			if err1 != nil || err2 != nil {
 				if !tt.wantErr {

--- a/telemetry-aware-scheduling/pkg/cache/mocks.go
+++ b/telemetry-aware-scheduling/pkg/cache/mocks.go
@@ -72,6 +72,12 @@ var mockPolicy = telemetrypolicy.TASPolicy{
 var mockPolicy2 = telemetrypolicy.TASPolicy{
 	ObjectMeta: v1.ObjectMeta{Name: "not-mock-policy", Namespace: "default"},
 }
+var mockInvalidPolicyName1 = telemetrypolicy.TASPolicy{
+	ObjectMeta: v1.ObjectMeta{Name: "", Namespace: "default"},
+}
+var mockInvalidPolicyName2 = telemetrypolicy.TASPolicy{
+	ObjectMeta: v1.ObjectMeta{Name: "n", Namespace: "default"},
+}
 
 // ReadMetric is a method implemented for Mock cache.
 func (n MockCache) ReadMetric(string) (metrics.NodeMetricsInfo, error) {


### PR DESCRIPTION
This will contains the following validations:
- Validating metric name before writing to cache
- Validate policy name before adding to metrics cache
- Add validation regex for metricname in CRD