### PR TITLE
Give read permissions to all remaining GA workflows

### DIFF
--- a/.github/workflows/bm-job-exit-trigger.yaml
+++ b/.github/workflows/bm-job-exit-trigger.yaml
@@ -18,6 +18,8 @@ on:
         description: "CNO-CI branch name"
         value: ${{ jobs.exit-trigger.outputs.cno-ci-branch-name  }}
 
+permissions:
+  contents: read
 
 jobs:
   exit-trigger:

--- a/.github/workflows/checkout-cno-ci-repo-job.yaml
+++ b/.github/workflows/checkout-cno-ci-repo-job.yaml
@@ -21,6 +21,9 @@ on:
         required: true
         description: 'Token required to access the CNO-CI repo'
 
+permissions:
+  contents: read
+
 jobs:
   pull-ci:
     name: Pull ansible based scripts

--- a/.github/workflows/checkout-tas-repo-job.yaml
+++ b/.github/workflows/checkout-tas-repo-job.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   pull-tas:
     name: Pull TAS code


### PR DESCRIPTION
### Summary
This commit is used to address token vulnerabilities found through the OSSF code scanner
The following GA workflows were updated:
- checkout-cno-ci-repo-job
- checkout-tas-repo-job
- bm-job-exit-trigger
- 
### Testing
After the commit was pushed and the OSSF code scanner ran the corresponding vulnerabilities were closed: https://github.com/madalazar/platform-aware-scheduling/security/code-scanning?query=is%3Aclosed+branch%3Amaster

Ran the scorecard tool locally as well and the issue seems fixed: 
10 / 10 | Token-Permissions      | GitHub workflow tokens follow  | https://github.com/ossf/scorecard/blob/d55dbd12e6c03aaf7a81da69ce47b9ae141cccd0/docs/checks.md#token-permissions      | | | | principle of least privilege   